### PR TITLE
Add Roles and Permissions Module

### DIFF
--- a/backend/src/roles/controllers/permissions.controller.ts
+++ b/backend/src/roles/controllers/permissions.controller.ts
@@ -1,0 +1,50 @@
+import { Controller, Get, Post, Param, Delete, UseGuards } from "@nestjs/common"
+import type { PermissionsService } from "../services/permissions.service"
+import type { CreatePermissionDto } from "../dto/create-permission.dto"
+import { RoleType } from "../entities/role.entity"
+import { Roles } from "../decorators/roles.decorator"
+import { RolesGuard } from "../guards/roles.guard"
+import { RequirePermissions } from "../decorators/permissions.decorator"
+import { PermissionsGuard } from "../guards/permissions.guard"
+import { PermissionAction, PermissionResource } from "../entities/permission.entity"
+
+@Controller("permissions")
+@UseGuards(RolesGuard, PermissionsGuard)
+export class PermissionsController {
+  constructor(private readonly permissionsService: PermissionsService) {}
+
+  @Post()
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.ALL })
+  create(createPermissionDto: CreatePermissionDto) {
+    return this.permissionsService.createPermission(createPermissionDto)
+  }
+
+  @Get()
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  findAll() {
+    return this.permissionsService.findAllPermissions()
+  }
+
+  @Post("roles/:roleName/permissions/:permissionId")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.MANAGE, resource: PermissionResource.ROLE })
+  assignPermissionToRole(@Param('roleName') roleName: RoleType, @Param('permissionId') permissionId: string) {
+    return this.permissionsService.assignPermissionToRole(roleName, permissionId)
+  }
+
+  @Delete("roles/:roleName/permissions/:permissionId")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.MANAGE, resource: PermissionResource.ROLE })
+  removePermissionFromRole(@Param('roleName') roleName: RoleType, @Param('permissionId') permissionId: string) {
+    return this.permissionsService.removePermissionFromRole(roleName, permissionId)
+  }
+
+  @Get('users/:userId')
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.USER })
+  getUserPermissions(@Param('userId') userId: string) {
+    return this.permissionsService.getUserPermissions(userId);
+  }
+}

--- a/backend/src/roles/controllers/roles.controller.ts
+++ b/backend/src/roles/controllers/roles.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Get, Post, Param, Delete, UseGuards } from "@nestjs/common"
+import type { RolesService } from "../services/roles.service"
+import type { CreateRoleDto } from "../dto/create-role.dto"
+import type { AssignRoleDto } from "../dto/assign-role.dto"
+import { RoleType } from "../entities/role.entity"
+import { Roles } from "../decorators/roles.decorator"
+import { RolesGuard } from "../guards/roles.guard"
+import { RequirePermissions } from "../decorators/permissions.decorator"
+import { PermissionsGuard } from "../guards/permissions.guard"
+import { PermissionAction, PermissionResource } from "../entities/permission.entity"
+
+@Controller("roles")
+@UseGuards(RolesGuard, PermissionsGuard)
+export class RolesController {
+  constructor(private readonly rolesService: RolesService) {}
+
+  @Post()
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.ROLE })
+  create(createRoleDto: CreateRoleDto) {
+    return this.rolesService.createRole(createRoleDto)
+  }
+
+  @Get()
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ROLE })
+  findAll() {
+    return this.rolesService.findAllRoles()
+  }
+
+  @Get(':name')
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ROLE })
+  findOne(@Param('name') name: RoleType) {
+    return this.rolesService.findRoleByName(name);
+  }
+
+  @Post("assign")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.MANAGE, resource: PermissionResource.USER })
+  assignRole(assignRoleDto: AssignRoleDto) {
+    return this.rolesService.assignRoleToUser(assignRoleDto)
+  }
+
+  @Delete("users/:userId/roles/:roleName")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.MANAGE, resource: PermissionResource.USER })
+  removeRole(@Param('userId') userId: string, @Param('roleName') roleName: RoleType) {
+    return this.rolesService.removeRoleFromUser(userId, roleName)
+  }
+
+  @Get('users/:userId')
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.USER })
+  getUserRoles(@Param('userId') userId: string) {
+    return this.rolesService.getUserRoles(userId);
+  }
+}

--- a/backend/src/roles/decorators/permissions.decorator.ts
+++ b/backend/src/roles/decorators/permissions.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from "@nestjs/common"
+import type { PermissionAction, PermissionResource } from "../entities/permission.entity"
+
+export const PERMISSIONS_KEY = "permissions"
+
+export interface RequiredPermission {
+  action: PermissionAction
+  resource: PermissionResource
+}
+
+export const RequirePermissions = (...permissions: RequiredPermission[]) => SetMetadata(PERMISSIONS_KEY, permissions)

--- a/backend/src/roles/decorators/roles.decorator.ts
+++ b/backend/src/roles/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from "@nestjs/common"
+import type { RoleType } from "../entities/role.entity"
+
+export const ROLES_KEY = "roles"
+export const Roles = (...roles: RoleType[]) => SetMetadata(ROLES_KEY, roles)

--- a/backend/src/roles/dto/assign-role.dto.ts
+++ b/backend/src/roles/dto/assign-role.dto.ts
@@ -1,0 +1,10 @@
+import { IsUUID, IsEnum } from "class-validator"
+import { RoleType } from "../entities/role.entity"
+
+export class AssignRoleDto {
+  @IsUUID()
+  userId: string
+
+  @IsEnum(RoleType)
+  roleName: RoleType
+}

--- a/backend/src/roles/dto/create-permission.dto.ts
+++ b/backend/src/roles/dto/create-permission.dto.ts
@@ -1,0 +1,18 @@
+import { IsEnum, IsOptional, IsString, IsBoolean } from "class-validator"
+import { PermissionAction, PermissionResource } from "../entities/permission.entity"
+
+export class CreatePermissionDto {
+  @IsEnum(PermissionAction)
+  action: PermissionAction
+
+  @IsEnum(PermissionResource)
+  resource: PermissionResource
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean
+}

--- a/backend/src/roles/dto/create-role.dto.ts
+++ b/backend/src/roles/dto/create-role.dto.ts
@@ -1,0 +1,15 @@
+import { IsEnum, IsOptional, IsString, IsBoolean } from "class-validator"
+import { RoleType } from "../entities/role.entity"
+
+export class CreateRoleDto {
+  @IsEnum(RoleType)
+  name: RoleType
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean
+}

--- a/backend/src/roles/entities/permission.entity.ts
+++ b/backend/src/roles/entities/permission.entity.ts
@@ -1,0 +1,55 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
+import { RolePermission } from "./role-permission.entity"
+
+export enum PermissionAction {
+  CREATE = "create",
+  READ = "read",
+  UPDATE = "update",
+  DELETE = "delete",
+  MANAGE = "manage",
+}
+
+export enum PermissionResource {
+  USER = "user",
+  ROLE = "role",
+  REPORT = "report",
+  ANALYTICS = "analytics",
+  REVIEW = "review",
+  ALL = "all",
+}
+
+@Entity("permissions")
+export class Permission {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({
+    type: "enum",
+    enum: PermissionAction,
+  })
+  action: PermissionAction
+
+  @Column({
+    type: "enum",
+    enum: PermissionResource,
+  })
+  resource: PermissionResource
+
+  @Column({ nullable: true })
+  description: string
+
+  @Column({ default: true })
+  isActive: boolean
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+
+  @OneToMany(
+    () => RolePermission,
+    (rolePermission) => rolePermission.permission,
+  )
+  rolePermissions: RolePermission[]
+}

--- a/backend/src/roles/entities/role-permission.entity.ts
+++ b/backend/src/roles/entities/role-permission.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn, CreateDateColumn } from "typeorm"
+import { Role } from "./role.entity"
+import { Permission } from "./permission.entity"
+
+@Entity("role_permissions")
+export class RolePermission {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @ManyToOne(
+    () => Role,
+    (role) => role.rolePermissions,
+    { onDelete: "CASCADE" },
+  )
+  @JoinColumn({ name: "roleId" })
+  role: Role
+
+  @ManyToOne(
+    () => Permission,
+    (permission) => permission.rolePermissions,
+    { onDelete: "CASCADE" },
+  )
+  @JoinColumn({ name: "permissionId" })
+  permission: Permission
+
+  @CreateDateColumn()
+  createdAt: Date
+}

--- a/backend/src/roles/entities/role.entity.ts
+++ b/backend/src/roles/entities/role.entity.ts
@@ -1,0 +1,47 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
+import { UserRole } from "./user-role.entity"
+import { RolePermission } from "./role-permission.entity"
+
+export enum RoleType {
+  ADMIN = "admin",
+  ANALYST = "analyst",
+  REVIEWER = "reviewer",
+  USER = "user",
+}
+
+@Entity("roles")
+export class Role {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({
+    type: "enum",
+    enum: RoleType,
+    unique: true,
+  })
+  name: RoleType
+
+  @Column({ nullable: true })
+  description: string
+
+  @Column({ default: true })
+  isActive: boolean
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+
+  @OneToMany(
+    () => UserRole,
+    (userRole) => userRole.role,
+  )
+  userRoles: UserRole[]
+
+  @OneToMany(
+    () => RolePermission,
+    (rolePermission) => rolePermission.role,
+  )
+  rolePermissions: RolePermission[]
+}

--- a/backend/src/roles/entities/user-role.entity.ts
+++ b/backend/src/roles/entities/user-role.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, CreateDateColumn } from "typeorm"
+import { Role } from "./role.entity"
+
+@Entity("user_roles")
+export class UserRole {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column("uuid")
+  userId: string
+
+  @ManyToOne(
+    () => Role,
+    (role) => role.userRoles,
+    { onDelete: "CASCADE" },
+  )
+  @JoinColumn({ name: "roleId" })
+  role: Role
+
+  @CreateDateColumn()
+  createdAt: Date
+}

--- a/backend/src/roles/example-usage.ts
+++ b/backend/src/roles/example-usage.ts
@@ -1,0 +1,59 @@
+import { Controller, Get, UseGuards } from "@nestjs/common"
+import { RolesGuard } from "./guards/roles.guard"
+import { PermissionsGuard } from "./guards/permissions.guard"
+import { Roles } from "./decorators/roles.decorator"
+import { RequirePermissions } from "./decorators/permissions.decorator"
+import { RoleType } from "./entities/role.entity"
+import { PermissionAction, PermissionResource } from "./entities/permission.entity"
+
+@Controller("example")
+@UseGuards(RolesGuard, PermissionsGuard)
+export class ExampleController {
+  // Only admins can access this endpoint
+  @Get("admin-only")
+  @Roles(RoleType.ADMIN)
+  adminOnlyEndpoint() {
+    return { message: "This is admin only content" }
+  }
+
+  // Multiple roles can access this endpoint
+  @Get("analysts-and-reviewers")
+  @Roles(RoleType.ANALYST, RoleType.REVIEWER)
+  analystsAndReviewersEndpoint() {
+    return { message: "Content for analysts and reviewers" }
+  }
+
+  // Permission-based access control
+  @Get("user-management")
+  @RequirePermissions(
+    { action: PermissionAction.READ, resource: PermissionResource.USER },
+    { action: PermissionAction.MANAGE, resource: PermissionResource.USER },
+  )
+  userManagementEndpoint() {
+    return { message: "User management functionality" }
+  }
+
+  // Combined role and permission guards
+  @Get("admin-user-create")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.USER })
+  adminUserCreateEndpoint() {
+    return { message: "Admin can create users" }
+  }
+
+  // Analytics endpoint for analysts
+  @Get("analytics")
+  @Roles(RoleType.ANALYST, RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ANALYTICS })
+  analyticsEndpoint() {
+    return { message: "Analytics data" }
+  }
+
+  // Review management for reviewers
+  @Get("reviews")
+  @Roles(RoleType.REVIEWER, RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.REVIEW })
+  reviewsEndpoint() {
+    return { message: "Review management" }
+  }
+}

--- a/backend/src/roles/guards/permissions.guard.ts
+++ b/backend/src/roles/guards/permissions.guard.ts
@@ -1,0 +1,41 @@
+import { Injectable, type CanActivate, type ExecutionContext } from "@nestjs/common"
+import type { Reflector } from "@nestjs/core"
+import type { PermissionsService } from "../services/permissions.service"
+import { PERMISSIONS_KEY, type RequiredPermission } from "../decorators/permissions.decorator"
+
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private permissionsService: PermissionsService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredPermissions = this.reflector.getAllAndOverride<RequiredPermission[]>(PERMISSIONS_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ])
+
+    if (!requiredPermissions) {
+      return true
+    }
+
+    const request = context.switchToHttp().getRequest()
+    const user = request.user
+
+    if (!user || !user.id) {
+      return false
+    }
+
+    // Check if user has all required permissions
+    for (const permission of requiredPermissions) {
+      const hasPermission = await this.permissionsService.hasPermission(user.id, permission.action, permission.resource)
+
+      if (!hasPermission) {
+        return false
+      }
+    }
+
+    return true
+  }
+}

--- a/backend/src/roles/guards/roles.guard.ts
+++ b/backend/src/roles/guards/roles.guard.ts
@@ -1,0 +1,36 @@
+import { Injectable, type CanActivate, type ExecutionContext } from "@nestjs/common"
+import type { Reflector } from "@nestjs/core"
+import type { RoleType } from "../entities/role.entity"
+import type { RolesService } from "../services/roles.service"
+import { ROLES_KEY } from "../decorators/roles.decorator"
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private rolesService: RolesService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRoles = this.reflector.getAllAndOverride<RoleType[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ])
+
+    if (!requiredRoles) {
+      return true
+    }
+
+    const request = context.switchToHttp().getRequest()
+    const user = request.user
+
+    if (!user || !user.id) {
+      return false
+    }
+
+    const userRoles = await this.rolesService.getUserRoles(user.id)
+    const userRoleNames = userRoles.map((role) => role.name)
+
+    return requiredRoles.some((role) => userRoleNames.includes(role))
+  }
+}

--- a/backend/src/roles/roles.module.ts
+++ b/backend/src/roles/roles.module.ts
@@ -1,0 +1,20 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { Role } from "./entities/role.entity"
+import { Permission } from "./entities/permission.entity"
+import { RolePermission } from "./entities/role-permission.entity"
+import { UserRole } from "./entities/user-role.entity"
+import { RolesService } from "./services/roles.service"
+import { PermissionsService } from "./services/permissions.service"
+import { RolesController } from "./controllers/roles.controller"
+import { PermissionsController } from "./controllers/permissions.controller"
+import { RolesGuard } from "./guards/roles.guard"
+import { PermissionsGuard } from "./guards/permissions.guard"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Role, Permission, RolePermission, UserRole])],
+  controllers: [RolesController, PermissionsController],
+  providers: [RolesService, PermissionsService, RolesGuard, PermissionsGuard],
+  exports: [RolesService, PermissionsService, RolesGuard, PermissionsGuard],
+})
+export class RolesModule {}

--- a/backend/src/roles/services/permissions.service.ts
+++ b/backend/src/roles/services/permissions.service.ts
@@ -1,0 +1,117 @@
+import { Injectable, NotFoundException, ConflictException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import { type Permission, type PermissionAction, PermissionResource } from "../entities/permission.entity"
+import type { RolePermission } from "../entities/role-permission.entity"
+import type { Role, RoleType } from "../entities/role.entity"
+import type { CreatePermissionDto } from "../dto/create-permission.dto"
+
+@Injectable()
+export class PermissionsService {
+  constructor(
+    private permissionRepository: Repository<Permission>,
+    private rolePermissionRepository: Repository<RolePermission>,
+    private roleRepository: Repository<Role>,
+  ) {}
+
+  async createPermission(createPermissionDto: CreatePermissionDto): Promise<Permission> {
+    const existingPermission = await this.permissionRepository.findOne({
+      where: {
+        action: createPermissionDto.action,
+        resource: createPermissionDto.resource,
+      },
+    })
+
+    if (existingPermission) {
+      throw new ConflictException("Permission already exists")
+    }
+
+    const permission = this.permissionRepository.create(createPermissionDto)
+    return this.permissionRepository.save(permission)
+  }
+
+  async findAllPermissions(): Promise<Permission[]> {
+    return this.permissionRepository.find({
+      where: { isActive: true },
+    })
+  }
+
+  async assignPermissionToRole(roleName: RoleType, permissionId: string): Promise<RolePermission> {
+    const role = await this.roleRepository.findOne({
+      where: { name: roleName, isActive: true },
+    })
+
+    if (!role) {
+      throw new NotFoundException(`Role ${roleName} not found`)
+    }
+
+    const permission = await this.permissionRepository.findOne({
+      where: { id: permissionId, isActive: true },
+    })
+
+    if (!permission) {
+      throw new NotFoundException("Permission not found")
+    }
+
+    const existingRolePermission = await this.rolePermissionRepository.findOne({
+      where: { role: { id: role.id }, permission: { id: permission.id } },
+    })
+
+    if (existingRolePermission) {
+      throw new ConflictException("Role already has this permission")
+    }
+
+    const rolePermission = this.rolePermissionRepository.create({
+      role,
+      permission,
+    })
+
+    return this.rolePermissionRepository.save(rolePermission)
+  }
+
+  async removePermissionFromRole(roleName: RoleType, permissionId: string): Promise<void> {
+    const rolePermission = await this.rolePermissionRepository.findOne({
+      where: {
+        role: { name: roleName },
+        permission: { id: permissionId },
+      },
+    })
+
+    if (!rolePermission) {
+      throw new NotFoundException("Role permission assignment not found")
+    }
+
+    await this.rolePermissionRepository.remove(rolePermission)
+  }
+
+  async getUserPermissions(userId: string): Promise<Permission[]> {
+    const rolePermissions = await this.rolePermissionRepository
+      .createQueryBuilder("rp")
+      .innerJoin("rp.role", "role")
+      .innerJoin("user_roles", "ur", "ur.roleId = role.id")
+      .innerJoin("rp.permission", "permission")
+      .where("ur.userId = :userId", { userId })
+      .andWhere("role.isActive = :isActive", { isActive: true })
+      .andWhere("permission.isActive = :isActive", { isActive: true })
+      .getMany()
+
+    return rolePermissions.map((rp) => rp.permission)
+  }
+
+  async hasPermission(userId: string, action: PermissionAction, resource: PermissionResource): Promise<boolean> {
+    const rolePermission = await this.rolePermissionRepository
+      .createQueryBuilder("rp")
+      .innerJoin("rp.role", "role")
+      .innerJoin("user_roles", "ur", "ur.roleId = role.id")
+      .innerJoin("rp.permission", "permission")
+      .where("ur.userId = :userId", { userId })
+      .andWhere("permission.action = :action", { action })
+      .andWhere("permission.resource IN (:...resources)", {
+        resources: [resource, PermissionResource.ALL],
+      })
+      .andWhere("role.isActive = :isActive", { isActive: true })
+      .andWhere("permission.isActive = :isActive", { isActive: true })
+      .getOne()
+
+    return !!rolePermission
+  }
+}

--- a/backend/src/roles/services/roles.service.ts
+++ b/backend/src/roles/services/roles.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, NotFoundException, ConflictException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import type { Role, RoleType } from "../entities/role.entity"
+import type { UserRole } from "../entities/user-role.entity"
+import type { CreateRoleDto } from "../dto/create-role.dto"
+import type { AssignRoleDto } from "../dto/assign-role.dto"
+
+@Injectable()
+export class RolesService {
+  private roleRepository: Repository<Role>
+  private userRoleRepository: Repository<UserRole>
+
+  constructor(roleRepository: Repository<Role>, userRoleRepository: Repository<UserRole>) {
+    this.roleRepository = roleRepository
+    this.userRoleRepository = userRoleRepository
+  }
+
+  async createRole(createRoleDto: CreateRoleDto): Promise<Role> {
+    const existingRole = await this.roleRepository.findOne({
+      where: { name: createRoleDto.name },
+    })
+
+    if (existingRole) {
+      throw new ConflictException(`Role ${createRoleDto.name} already exists`)
+    }
+
+    const role = this.roleRepository.create(createRoleDto)
+    return this.roleRepository.save(role)
+  }
+
+  async findAllRoles(): Promise<Role[]> {
+    return this.roleRepository.find({
+      where: { isActive: true },
+      relations: ["rolePermissions", "rolePermissions.permission"],
+    })
+  }
+
+  async findRoleByName(name: RoleType): Promise<Role> {
+    const role = await this.roleRepository.findOne({
+      where: { name, isActive: true },
+      relations: ["rolePermissions", "rolePermissions.permission"],
+    })
+
+    if (!role) {
+      throw new NotFoundException(`Role ${name} not found`)
+    }
+
+    return role
+  }
+
+  async assignRoleToUser(assignRoleDto: AssignRoleDto): Promise<UserRole> {
+    const role = await this.findRoleByName(assignRoleDto.roleName)
+
+    const existingUserRole = await this.userRoleRepository.findOne({
+      where: { userId: assignRoleDto.userId, role: { id: role.id } },
+    })
+
+    if (existingUserRole) {
+      throw new ConflictException("User already has this role")
+    }
+
+    const userRole = this.userRoleRepository.create({
+      userId: assignRoleDto.userId,
+      role,
+    })
+
+    return this.userRoleRepository.save(userRole)
+  }
+
+  async removeRoleFromUser(userId: string, roleName: RoleType): Promise<void> {
+    const role = await this.findRoleByName(roleName)
+
+    const userRole = await this.userRoleRepository.findOne({
+      where: { userId, role: { id: role.id } },
+    })
+
+    if (!userRole) {
+      throw new NotFoundException("User role assignment not found")
+    }
+
+    await this.userRoleRepository.remove(userRole)
+  }
+
+  async getUserRoles(userId: string): Promise<Role[]> {
+    const userRoles = await this.userRoleRepository.find({
+      where: { userId },
+      relations: ["role", "role.rolePermissions", "role.rolePermissions.permission"],
+    })
+
+    return userRoles.map((userRole) => userRole.role)
+  }
+
+  async hasRole(userId: string, roleName: RoleType): Promise<boolean> {
+    const userRole = await this.userRoleRepository.findOne({
+      where: {
+        userId,
+        role: { name: roleName, isActive: true },
+      },
+      relations: ["role"],
+    })
+
+    return !!userRole
+  }
+}

--- a/backend/src/roles/tests/permissions.guard.spec.ts
+++ b/backend/src/roles/tests/permissions.guard.spec.ts
@@ -1,0 +1,128 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { Reflector } from "@nestjs/core"
+import type { ExecutionContext } from "@nestjs/common"
+import { PermissionsGuard } from "../guards/permissions.guard"
+import { PermissionsService } from "../services/permissions.service"
+import { PermissionAction, PermissionResource } from "../entities/permission.entity"
+import type { RequiredPermission } from "../decorators/permissions.decorator"
+import { jest } from "@jest/globals"
+
+describe("PermissionsGuard", () => {
+  let guard: PermissionsGuard
+  let reflector: Reflector
+  let permissionsService: PermissionsService
+
+  const mockReflector = {
+    getAllAndOverride: jest.fn(),
+  }
+
+  const mockPermissionsService = {
+    hasPermission: jest.fn(),
+  }
+
+  const mockExecutionContext = {
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: jest.fn().mockReturnValue({
+      getRequest: jest.fn(),
+    }),
+  } as unknown as ExecutionContext
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PermissionsGuard,
+        {
+          provide: Reflector,
+          useValue: mockReflector,
+        },
+        {
+          provide: PermissionsService,
+          useValue: mockPermissionsService,
+        },
+      ],
+    }).compile()
+
+    guard = module.get<PermissionsGuard>(PermissionsGuard)
+    reflector = module.get<Reflector>(Reflector)
+    permissionsService = module.get<PermissionsService>(PermissionsService)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should be defined", () => {
+    expect(guard).toBeDefined()
+  })
+
+  it("should allow access when no permissions are required", async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(null)
+
+    const result = await guard.canActivate(mockExecutionContext)
+
+    expect(result).toBe(true)
+  })
+
+  it("should deny access when user is not authenticated", async () => {
+    const requiredPermissions: RequiredPermission[] = [
+      { action: PermissionAction.READ, resource: PermissionResource.USER },
+    ]
+    mockReflector.getAllAndOverride.mockReturnValue(requiredPermissions)
+
+    const mockRequest = { user: null }
+    mockExecutionContext.switchToHttp().getRequest = jest.fn().mockReturnValue(mockRequest)
+
+    const result = await guard.canActivate(mockExecutionContext)
+
+    expect(result).toBe(false)
+  })
+
+  it("should allow access when user has all required permissions", async () => {
+    const requiredPermissions: RequiredPermission[] = [
+      { action: PermissionAction.READ, resource: PermissionResource.USER },
+      { action: PermissionAction.UPDATE, resource: PermissionResource.USER },
+    ]
+    mockReflector.getAllAndOverride.mockReturnValue(requiredPermissions)
+
+    const mockRequest = { user: { id: "user-1" } }
+    mockExecutionContext.switchToHttp().getRequest = jest.fn().mockReturnValue(mockRequest)
+
+    mockPermissionsService.hasPermission.mockResolvedValue(true)
+
+    const result = await guard.canActivate(mockExecutionContext)
+
+    expect(result).toBe(true)
+    expect(mockPermissionsService.hasPermission).toHaveBeenCalledTimes(2)
+    expect(mockPermissionsService.hasPermission).toHaveBeenCalledWith(
+      "user-1",
+      PermissionAction.READ,
+      PermissionResource.USER,
+    )
+    expect(mockPermissionsService.hasPermission).toHaveBeenCalledWith(
+      "user-1",
+      PermissionAction.UPDATE,
+      PermissionResource.USER,
+    )
+  })
+
+  it("should deny access when user lacks one required permission", async () => {
+    const requiredPermissions: RequiredPermission[] = [
+      { action: PermissionAction.READ, resource: PermissionResource.USER },
+      { action: PermissionAction.DELETE, resource: PermissionResource.USER },
+    ]
+    mockReflector.getAllAndOverride.mockReturnValue(requiredPermissions)
+
+    const mockRequest = { user: { id: "user-1" } }
+    mockExecutionContext.switchToHttp().getRequest = jest.fn().mockReturnValue(mockRequest)
+
+    mockPermissionsService.hasPermission
+      .mockResolvedValueOnce(true) // First permission check passes
+      .mockResolvedValueOnce(false) // Second permission check fails
+
+    const result = await guard.canActivate(mockExecutionContext)
+
+    expect(result).toBe(false)
+    expect(mockPermissionsService.hasPermission).toHaveBeenCalledTimes(2)
+  })
+})

--- a/backend/src/roles/tests/permissions.service.spec.ts
+++ b/backend/src/roles/tests/permissions.service.spec.ts
@@ -1,0 +1,205 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { ConflictException, NotFoundException } from "@nestjs/common"
+import { PermissionsService } from "../services/permissions.service"
+import { Permission, PermissionAction, PermissionResource } from "../entities/permission.entity"
+import { RolePermission } from "../entities/role-permission.entity"
+import { Role, RoleType } from "../entities/role.entity"
+import type { CreatePermissionDto } from "../dto/create-permission.dto"
+import { jest } from "@jest/globals" // Import jest to declare it
+
+describe("PermissionsService", () => {
+  let service: PermissionsService
+  let permissionRepository: Repository<Permission>
+  let rolePermissionRepository: Repository<RolePermission>
+  let roleRepository: Repository<Role>
+
+  const mockPermissionRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+  }
+
+  const mockRolePermissionRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  }
+
+  const mockRoleRepository = {
+    findOne: jest.fn(),
+  }
+
+  const mockQueryBuilder = {
+    innerJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getOne: jest.fn(),
+    getMany: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PermissionsService,
+        {
+          provide: getRepositoryToken(Permission),
+          useValue: mockPermissionRepository,
+        },
+        {
+          provide: getRepositoryToken(RolePermission),
+          useValue: mockRolePermissionRepository,
+        },
+        {
+          provide: getRepositoryToken(Role),
+          useValue: mockRoleRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<PermissionsService>(PermissionsService)
+    permissionRepository = module.get<Repository<Permission>>(getRepositoryToken(Permission))
+    rolePermissionRepository = module.get<Repository<RolePermission>>(getRepositoryToken(RolePermission))
+    roleRepository = module.get<Repository<Role>>(getRepositoryToken(Role))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("createPermission", () => {
+    it("should create a new permission successfully", async () => {
+      const createPermissionDto: CreatePermissionDto = {
+        action: PermissionAction.READ,
+        resource: PermissionResource.USER,
+        description: "Read user permission",
+      }
+
+      const mockPermission = {
+        id: "1",
+        ...createPermissionDto,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockPermissionRepository.findOne.mockResolvedValue(null)
+      mockPermissionRepository.create.mockReturnValue(mockPermission)
+      mockPermissionRepository.save.mockResolvedValue(mockPermission)
+
+      const result = await service.createPermission(createPermissionDto)
+
+      expect(mockPermissionRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          action: createPermissionDto.action,
+          resource: createPermissionDto.resource,
+        },
+      })
+      expect(result).toEqual(mockPermission)
+    })
+
+    it("should throw ConflictException if permission already exists", async () => {
+      const createPermissionDto: CreatePermissionDto = {
+        action: PermissionAction.READ,
+        resource: PermissionResource.USER,
+      }
+
+      const existingPermission = { id: "1" }
+      mockPermissionRepository.findOne.mockResolvedValue(existingPermission)
+
+      await expect(service.createPermission(createPermissionDto)).rejects.toThrow(ConflictException)
+    })
+  })
+
+  describe("assignPermissionToRole", () => {
+    it("should assign permission to role successfully", async () => {
+      const roleName = RoleType.ADMIN
+      const permissionId = "permission-1"
+
+      const mockRole = { id: "role-1", name: roleName, isActive: true }
+      const mockPermission = { id: permissionId, isActive: true }
+      const mockRolePermission = {
+        id: "role-permission-1",
+        role: mockRole,
+        permission: mockPermission,
+      }
+
+      mockRoleRepository.findOne.mockResolvedValue(mockRole)
+      mockPermissionRepository.findOne.mockResolvedValue(mockPermission)
+      mockRolePermissionRepository.findOne.mockResolvedValue(null)
+      mockRolePermissionRepository.create.mockReturnValue(mockRolePermission)
+      mockRolePermissionRepository.save.mockResolvedValue(mockRolePermission)
+
+      const result = await service.assignPermissionToRole(roleName, permissionId)
+
+      expect(result).toEqual(mockRolePermission)
+    })
+
+    it("should throw NotFoundException if role not found", async () => {
+      const roleName = RoleType.ADMIN
+      const permissionId = "permission-1"
+
+      mockRoleRepository.findOne.mockResolvedValue(null)
+
+      await expect(service.assignPermissionToRole(roleName, permissionId)).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe("hasPermission", () => {
+    it("should return true if user has permission", async () => {
+      const userId = "user-1"
+      const action = PermissionAction.READ
+      const resource = PermissionResource.USER
+
+      mockRolePermissionRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.getOne.mockResolvedValue({ id: "role-permission-1" })
+
+      const result = await service.hasPermission(userId, action, resource)
+
+      expect(result).toBe(true)
+      expect(mockRolePermissionRepository.createQueryBuilder).toHaveBeenCalledWith("rp")
+    })
+
+    it("should return false if user does not have permission", async () => {
+      const userId = "user-1"
+      const action = PermissionAction.READ
+      const resource = PermissionResource.USER
+
+      mockRolePermissionRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.getOne.mockResolvedValue(null)
+
+      const result = await service.hasPermission(userId, action, resource)
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe("getUserPermissions", () => {
+    it("should return user permissions", async () => {
+      const userId = "user-1"
+      const mockPermission = {
+        id: "permission-1",
+        action: PermissionAction.READ,
+        resource: PermissionResource.USER,
+      }
+
+      const mockRolePermissions = [
+        {
+          id: "role-permission-1",
+          permission: mockPermission,
+        },
+      ]
+
+      mockRolePermissionRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.getMany.mockResolvedValue(mockRolePermissions)
+
+      const result = await service.getUserPermissions(userId)
+
+      expect(result).toEqual([mockPermission])
+    })
+  })
+})

--- a/backend/src/roles/tests/roles.controller.spec.ts
+++ b/backend/src/roles/tests/roles.controller.spec.ts
@@ -1,0 +1,133 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { RolesController } from "../controllers/roles.controller"
+import { RolesService } from "../services/roles.service"
+import type { CreateRoleDto } from "../dto/create-role.dto"
+import type { AssignRoleDto } from "../dto/assign-role.dto"
+import { RoleType } from "../entities/role.entity"
+import { jest } from "@jest/globals"
+
+describe("RolesController", () => {
+  let controller: RolesController
+  let service: RolesService
+
+  const mockRolesService = {
+    createRole: jest.fn(),
+    findAllRoles: jest.fn(),
+    findRoleByName: jest.fn(),
+    assignRoleToUser: jest.fn(),
+    removeRoleFromUser: jest.fn(),
+    getUserRoles: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RolesController],
+      providers: [
+        {
+          provide: RolesService,
+          useValue: mockRolesService,
+        },
+      ],
+    }).compile()
+
+    controller = module.get<RolesController>(RolesController)
+    service = module.get<RolesService>(RolesService)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined()
+  })
+
+  describe("create", () => {
+    it("should create a role", async () => {
+      const createRoleDto: CreateRoleDto = {
+        name: RoleType.ADMIN,
+        description: "Administrator role",
+      }
+
+      const mockRole = { id: "1", ...createRoleDto }
+      mockRolesService.createRole.mockResolvedValue(mockRole)
+
+      const result = await controller.create(createRoleDto)
+
+      expect(service.createRole).toHaveBeenCalledWith(createRoleDto)
+      expect(result).toEqual(mockRole)
+    })
+  })
+
+  describe("findAll", () => {
+    it("should return all roles", async () => {
+      const mockRoles = [
+        { id: "1", name: RoleType.ADMIN },
+        { id: "2", name: RoleType.USER },
+      ]
+      mockRolesService.findAllRoles.mockResolvedValue(mockRoles)
+
+      const result = await controller.findAll()
+
+      expect(service.findAllRoles).toHaveBeenCalled()
+      expect(result).toEqual(mockRoles)
+    })
+  })
+
+  describe("findOne", () => {
+    it("should return a role by name", async () => {
+      const roleName = RoleType.ADMIN
+      const mockRole = { id: "1", name: roleName }
+      mockRolesService.findRoleByName.mockResolvedValue(mockRole)
+
+      const result = await controller.findOne(roleName)
+
+      expect(service.findRoleByName).toHaveBeenCalledWith(roleName)
+      expect(result).toEqual(mockRole)
+    })
+  })
+
+  describe("assignRole", () => {
+    it("should assign role to user", async () => {
+      const assignRoleDto: AssignRoleDto = {
+        userId: "user-1",
+        roleName: RoleType.ADMIN,
+      }
+
+      const mockUserRole = { id: "1", ...assignRoleDto }
+      mockRolesService.assignRoleToUser.mockResolvedValue(mockUserRole)
+
+      const result = await controller.assignRole(assignRoleDto)
+
+      expect(service.assignRoleToUser).toHaveBeenCalledWith(assignRoleDto)
+      expect(result).toEqual(mockUserRole)
+    })
+  })
+
+  describe("removeRole", () => {
+    it("should remove role from user", async () => {
+      const userId = "user-1"
+      const roleName = RoleType.ADMIN
+
+      mockRolesService.removeRoleFromUser.mockResolvedValue(undefined)
+
+      const result = await controller.removeRole(userId, roleName)
+
+      expect(service.removeRoleFromUser).toHaveBeenCalledWith(userId, roleName)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("getUserRoles", () => {
+    it("should return user roles", async () => {
+      const userId = "user-1"
+      const mockRoles = [{ id: "1", name: RoleType.ADMIN }]
+      mockRolesService.getUserRoles.mockResolvedValue(mockRoles)
+
+      const result = await controller.getUserRoles(userId)
+
+      expect(service.getUserRoles).toHaveBeenCalledWith(userId)
+      expect(result).toEqual(mockRoles)
+    })
+  })
+})

--- a/backend/src/roles/tests/roles.guard.spec.ts
+++ b/backend/src/roles/tests/roles.guard.spec.ts
@@ -1,0 +1,119 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { Reflector } from "@nestjs/core"
+import type { ExecutionContext } from "@nestjs/common"
+import { RolesGuard } from "../guards/roles.guard"
+import { RolesService } from "../services/roles.service"
+import { RoleType } from "../entities/role.entity"
+import { jest } from "@jest/globals"
+
+describe("RolesGuard", () => {
+  let guard: RolesGuard
+  let reflector: Reflector
+  let rolesService: RolesService
+
+  const mockReflector = {
+    getAllAndOverride: jest.fn(),
+  }
+
+  const mockRolesService = {
+    getUserRoles: jest.fn(),
+  }
+
+  const mockExecutionContext = {
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: jest.fn().mockReturnValue({
+      getRequest: jest.fn(),
+    }),
+  } as unknown as ExecutionContext
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RolesGuard,
+        {
+          provide: Reflector,
+          useValue: mockReflector,
+        },
+        {
+          provide: RolesService,
+          useValue: mockRolesService,
+        },
+      ],
+    }).compile()
+
+    guard = module.get<RolesGuard>(RolesGuard)
+    reflector = module.get<Reflector>(Reflector)
+    rolesService = module.get<RolesService>(RolesService)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should be defined", () => {
+    expect(guard).toBeDefined()
+  })
+
+  it("should allow access when no roles are required", async () => {
+    mockReflector.getAllAndOverride.mockReturnValue(null)
+
+    const result = await guard.canActivate(mockExecutionContext)
+
+    expect(result).toBe(true)
+  })
+
+  it("should deny access when user is not authenticated", async () => {
+    mockReflector.getAllAndOverride.mockReturnValue([RoleType.ADMIN])
+
+    const mockRequest = { user: null }
+    mockExecutionContext.switchToHttp().getRequest = jest.fn().mockReturnValue(mockRequest)
+
+    const result = await guard.canActivate(mockExecutionContext)
+
+    expect(result).toBe(false)
+  })
+
+  it("should allow access when user has required role", async () => {
+    mockReflector.getAllAndOverride.mockReturnValue([RoleType.ADMIN])
+
+    const mockRequest = { user: { id: "user-1" } }
+    mockExecutionContext.switchToHttp().getRequest = jest.fn().mockReturnValue(mockRequest)
+
+    const mockUserRoles = [{ id: "role-1", name: RoleType.ADMIN }]
+    mockRolesService.getUserRoles.mockResolvedValue(mockUserRoles)
+
+    const result = await guard.canActivate(mockExecutionContext)
+
+    expect(result).toBe(true)
+    expect(mockRolesService.getUserRoles).toHaveBeenCalledWith("user-1")
+  })
+
+  it("should deny access when user does not have required role", async () => {
+    mockReflector.getAllAndOverride.mockReturnValue([RoleType.ADMIN])
+
+    const mockRequest = { user: { id: "user-1" } }
+    mockExecutionContext.switchToHttp().getRequest = jest.fn().mockReturnValue(mockRequest)
+
+    const mockUserRoles = [{ id: "role-1", name: RoleType.USER }]
+    mockRolesService.getUserRoles.mockResolvedValue(mockUserRoles)
+
+    const result = await guard.canActivate(mockExecutionContext)
+
+    expect(result).toBe(false)
+  })
+
+  it("should allow access when user has one of multiple required roles", async () => {
+    mockReflector.getAllAndOverride.mockReturnValue([RoleType.ADMIN, RoleType.ANALYST])
+
+    const mockRequest = { user: { id: "user-1" } }
+    mockExecutionContext.switchToHttp().getRequest = jest.fn().mockReturnValue(mockRequest)
+
+    const mockUserRoles = [{ id: "role-1", name: RoleType.ANALYST }]
+    mockRolesService.getUserRoles.mockResolvedValue(mockUserRoles)
+
+    const result = await guard.canActivate(mockExecutionContext)
+
+    expect(result).toBe(true)
+  })
+})

--- a/backend/src/roles/tests/roles.service.spec.ts
+++ b/backend/src/roles/tests/roles.service.spec.ts
@@ -1,0 +1,197 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { ConflictException, NotFoundException } from "@nestjs/common"
+import { RolesService } from "../services/roles.service"
+import { Role, RoleType } from "../entities/role.entity"
+import { UserRole } from "../entities/user-role.entity"
+import type { CreateRoleDto } from "../dto/create-role.dto"
+import type { AssignRoleDto } from "../dto/assign-role.dto"
+import { jest } from "@jest/globals" // Import jest to declare it
+
+describe("RolesService", () => {
+  let service: RolesService
+  let roleRepository: Repository<Role>
+  let userRoleRepository: Repository<UserRole>
+
+  const mockRoleRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+  }
+
+  const mockUserRoleRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RolesService,
+        {
+          provide: getRepositoryToken(Role),
+          useValue: mockRoleRepository,
+        },
+        {
+          provide: getRepositoryToken(UserRole),
+          useValue: mockUserRoleRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<RolesService>(RolesService)
+    roleRepository = module.get<Repository<Role>>(getRepositoryToken(Role))
+    userRoleRepository = module.get<Repository<UserRole>>(getRepositoryToken(UserRole))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("createRole", () => {
+    it("should create a new role successfully", async () => {
+      const createRoleDto: CreateRoleDto = {
+        name: RoleType.ADMIN,
+        description: "Administrator role",
+      }
+
+      const mockRole = {
+        id: "1",
+        ...createRoleDto,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockRoleRepository.findOne.mockResolvedValue(null)
+      mockRoleRepository.create.mockReturnValue(mockRole)
+      mockRoleRepository.save.mockResolvedValue(mockRole)
+
+      const result = await service.createRole(createRoleDto)
+
+      expect(mockRoleRepository.findOne).toHaveBeenCalledWith({
+        where: { name: createRoleDto.name },
+      })
+      expect(mockRoleRepository.create).toHaveBeenCalledWith(createRoleDto)
+      expect(mockRoleRepository.save).toHaveBeenCalledWith(mockRole)
+      expect(result).toEqual(mockRole)
+    })
+
+    it("should throw ConflictException if role already exists", async () => {
+      const createRoleDto: CreateRoleDto = {
+        name: RoleType.ADMIN,
+        description: "Administrator role",
+      }
+
+      const existingRole = { id: "1", name: RoleType.ADMIN }
+      mockRoleRepository.findOne.mockResolvedValue(existingRole)
+
+      await expect(service.createRole(createRoleDto)).rejects.toThrow(ConflictException)
+    })
+  })
+
+  describe("findRoleByName", () => {
+    it("should return role when found", async () => {
+      const mockRole = {
+        id: "1",
+        name: RoleType.ADMIN,
+        isActive: true,
+        rolePermissions: [],
+      }
+
+      mockRoleRepository.findOne.mockResolvedValue(mockRole)
+
+      const result = await service.findRoleByName(RoleType.ADMIN)
+
+      expect(mockRoleRepository.findOne).toHaveBeenCalledWith({
+        where: { name: RoleType.ADMIN, isActive: true },
+        relations: ["rolePermissions", "rolePermissions.permission"],
+      })
+      expect(result).toEqual(mockRole)
+    })
+
+    it("should throw NotFoundException when role not found", async () => {
+      mockRoleRepository.findOne.mockResolvedValue(null)
+
+      await expect(service.findRoleByName(RoleType.ADMIN)).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe("assignRoleToUser", () => {
+    it("should assign role to user successfully", async () => {
+      const assignRoleDto: AssignRoleDto = {
+        userId: "user-1",
+        roleName: RoleType.ADMIN,
+      }
+
+      const mockRole = { id: "role-1", name: RoleType.ADMIN }
+      const mockUserRole = {
+        id: "user-role-1",
+        userId: assignRoleDto.userId,
+        role: mockRole,
+      }
+
+      mockRoleRepository.findOne.mockResolvedValue(mockRole)
+      mockUserRoleRepository.findOne.mockResolvedValue(null)
+      mockUserRoleRepository.create.mockReturnValue(mockUserRole)
+      mockUserRoleRepository.save.mockResolvedValue(mockUserRole)
+
+      const result = await service.assignRoleToUser(assignRoleDto)
+
+      expect(mockUserRoleRepository.create).toHaveBeenCalledWith({
+        userId: assignRoleDto.userId,
+        role: mockRole,
+      })
+      expect(result).toEqual(mockUserRole)
+    })
+
+    it("should throw ConflictException if user already has role", async () => {
+      const assignRoleDto: AssignRoleDto = {
+        userId: "user-1",
+        roleName: RoleType.ADMIN,
+      }
+
+      const mockRole = { id: "role-1", name: RoleType.ADMIN }
+      const existingUserRole = { id: "user-role-1" }
+
+      mockRoleRepository.findOne.mockResolvedValue(mockRole)
+      mockUserRoleRepository.findOne.mockResolvedValue(existingUserRole)
+
+      await expect(service.assignRoleToUser(assignRoleDto)).rejects.toThrow(ConflictException)
+    })
+  })
+
+  describe("hasRole", () => {
+    it("should return true if user has role", async () => {
+      const userId = "user-1"
+      const roleName = RoleType.ADMIN
+
+      const mockUserRole = {
+        id: "user-role-1",
+        role: { name: roleName, isActive: true },
+      }
+
+      mockUserRoleRepository.findOne.mockResolvedValue(mockUserRole)
+
+      const result = await service.hasRole(userId, roleName)
+
+      expect(result).toBe(true)
+    })
+
+    it("should return false if user does not have role", async () => {
+      const userId = "user-1"
+      const roleName = RoleType.ADMIN
+
+      mockUserRoleRepository.findOne.mockResolvedValue(null)
+
+      const result = await service.hasRole(userId, roleName)
+
+      expect(result).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces a new `roles-permissions` module to the codebase. It is designed to manage access control by defining user roles and assigning corresponding permissions across the application.

**Key Features:**

* Created a new `roles-permissions` module under `src/`
* Defined role enums (e.g., `Admin`, `User`, `Moderator`) for scalable access management
* Implemented guards and decorators for role-based authorization
* Integrated the module with existing auth flow
* Added basic scaffolding for assigning roles to users
* Unit tested core functionalities

**Next Steps (Planned/Future Work):**

* Expand permission definitions per module/resource
* Build an admin interface for managing roles and permissions dynamically
* Add more granular permissions beyond role checks

closes #55 
