### PR TITLE
Build Reporting Module for Smalda Backend

### DIFF
--- a/backend/src/reporting/dto/generate-report.dto.ts
+++ b/backend/src/reporting/dto/generate-report.dto.ts
@@ -1,0 +1,59 @@
+import { IsString, IsNotEmpty, IsOptional, IsEnum, IsDateString, IsObject, IsEmail, IsArray } from "class-validator"
+import { ReportType, ReportFormat } from "../entities/report.entity"
+
+export class GenerateReportDto {
+  @IsEnum(ReportType)
+  type: ReportType
+
+  @IsEnum(ReportFormat)
+  format: ReportFormat
+
+  @IsString()
+  @IsNotEmpty()
+  title: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsString()
+  @IsNotEmpty()
+  generatedBy: string
+
+  @IsEmail()
+  generatedByEmail: string
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  documentIds?: string[]
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  userIds?: string[]
+
+  @IsOptional()
+  @IsString()
+  riskLevel?: string
+
+  @IsOptional()
+  @IsString()
+  department?: string
+
+  @IsOptional()
+  @IsObject()
+  additionalFilters?: Record<string, any>
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/backend/src/reporting/dto/report-query.dto.ts
+++ b/backend/src/reporting/dto/report-query.dto.ts
@@ -1,0 +1,46 @@
+import { IsOptional, IsEnum, IsString, IsDateString, IsNumber, Min, Max } from "class-validator"
+import { Transform } from "class-transformer"
+import { ReportType, ReportFormat, ReportStatus } from "../entities/report.entity"
+
+export class ReportQueryDto {
+  @IsOptional()
+  @IsEnum(ReportType)
+  type?: ReportType
+
+  @IsOptional()
+  @IsEnum(ReportFormat)
+  format?: ReportFormat
+
+  @IsOptional()
+  @IsEnum(ReportStatus)
+  status?: ReportStatus
+
+  @IsOptional()
+  @IsString()
+  generatedBy?: string
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string
+
+  @IsOptional()
+  @Transform(({ value }) => Number.parseInt(value))
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number = 50
+
+  @IsOptional()
+  @Transform(({ value }) => Number.parseInt(value))
+  @IsNumber()
+  @Min(0)
+  offset?: number = 0
+
+  @IsOptional()
+  @IsString()
+  search?: string
+}

--- a/backend/src/reporting/entities/report.entity.ts
+++ b/backend/src/reporting/entities/report.entity.ts
@@ -1,0 +1,100 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from "typeorm"
+
+export enum ReportType {
+  DOCUMENT_ANALYSIS = "DOCUMENT_ANALYSIS",
+  RISK_SUMMARY = "RISK_SUMMARY",
+  AUDIT_TRAIL = "AUDIT_TRAIL",
+  USER_ACTIVITY = "USER_ACTIVITY",
+  SYSTEM_OVERVIEW = "SYSTEM_OVERVIEW",
+  COMPLIANCE = "COMPLIANCE",
+}
+
+export enum ReportFormat {
+  PDF = "PDF",
+  CSV = "CSV",
+  EXCEL = "EXCEL",
+  JSON = "JSON",
+}
+
+export enum ReportStatus {
+  PENDING = "PENDING",
+  GENERATING = "GENERATING",
+  COMPLETED = "COMPLETED",
+  FAILED = "FAILED",
+  EXPIRED = "EXPIRED",
+}
+
+@Entity("reports")
+@Index(["generatedBy", "createdAt"])
+@Index(["type", "status"])
+export class Report {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({
+    type: "enum",
+    enum: ReportType,
+  })
+  @Index()
+  type: ReportType
+
+  @Column({
+    type: "enum",
+    enum: ReportFormat,
+  })
+  format: ReportFormat
+
+  @Column({
+    type: "enum",
+    enum: ReportStatus,
+    default: ReportStatus.PENDING,
+  })
+  @Index()
+  status: ReportStatus
+
+  @Column()
+  title: string
+
+  @Column("text", { nullable: true })
+  description: string
+
+  @Column("jsonb")
+  parameters: Record<string, any>
+
+  @Column()
+  @Index()
+  generatedBy: string
+
+  @Column()
+  generatedByEmail: string
+
+  @Column({ nullable: true })
+  filePath: string
+
+  @Column({ nullable: true })
+  fileName: string
+
+  @Column({ default: 0 })
+  fileSize: number
+
+  @Column({ nullable: true })
+  downloadUrl: string
+
+  @Column({ type: "timestamp", nullable: true })
+  expiresAt: Date
+
+  @Column({ default: 0 })
+  downloadCount: number
+
+  @Column({ nullable: true })
+  errorMessage: string
+
+  @Column("jsonb", { nullable: true })
+  metadata: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/backend/src/reporting/interfaces/report-data.interface.ts
+++ b/backend/src/reporting/interfaces/report-data.interface.ts
@@ -1,0 +1,149 @@
+import type { RiskLevel } from "../../risk-analysis/entities/risk-analysis.entity"
+import type { AuditAction } from "../../audit-log/entities/audit-log.entity"
+
+export interface DocumentAnalysisReportData {
+  documents: Array<{
+    id: string
+    name: string
+    originalName: string
+    uploadedBy: string
+    uploadedAt: Date
+    size: number
+    mimeType: string
+    riskAnalysis?: {
+      id: string
+      riskLevel: RiskLevel
+      riskScore: number
+      summary: string
+      detectedKeywords: string[]
+      analyzedBy: string
+      analyzedAt: Date
+    }
+  }>
+  summary: {
+    totalDocuments: number
+    byRiskLevel: Record<RiskLevel, number>
+    byMimeType: Record<string, number>
+    averageRiskScore: number
+    totalSize: number
+  }
+}
+
+export interface RiskSummaryReportData {
+  riskAnalyses: Array<{
+    id: string
+    documentId: string
+    documentName: string
+    riskLevel: RiskLevel
+    riskScore: number
+    summary: string
+    detectedKeywords: string[]
+    riskFactors: Array<{
+      category: string
+      severity: string
+      description: string
+      score: number
+    }>
+    analyzedBy: string
+    analyzedAt: Date
+    uploadedBy: string
+  }>
+  summary: {
+    totalAnalyses: number
+    byRiskLevel: Record<RiskLevel, number>
+    averageRiskScore: number
+    topRiskFactors: Array<{ category: string; count: number }>
+    criticalDocuments: number
+  }
+}
+
+export interface AuditTrailReportData {
+  auditLogs: Array<{
+    id: string
+    userId: string
+    userEmail: string
+    action: AuditAction
+    description: string
+    resourceType: string
+    resourceId: string
+    success: boolean
+    ipAddress: string
+    createdAt: Date
+  }>
+  summary: {
+    totalLogs: number
+    byAction: Record<AuditAction, number>
+    byUser: Record<string, number>
+    failedOperations: number
+    successRate: number
+  }
+}
+
+export interface UserActivityReportData {
+  users: Array<{
+    id: string
+    email: string
+    fullName: string
+    role: string
+    department: string
+    documentsUploaded: number
+    documentsAnalyzed: number
+    lastActivity: Date
+    totalActions: number
+    riskDocuments: number
+  }>
+  summary: {
+    totalUsers: number
+    activeUsers: number
+    totalDocuments: number
+    totalAnalyses: number
+    byDepartment: Record<string, number>
+  }
+}
+
+export interface SystemOverviewReportData {
+  overview: {
+    totalDocuments: number
+    totalUsers: number
+    totalRiskAnalyses: number
+    totalAuditLogs: number
+    totalNotifications: number
+    systemUptime: string
+    lastBackup: Date
+  }
+  metrics: {
+    documentsPerDay: Array<{ date: string; count: number }>
+    riskTrends: Array<{ date: string; riskLevel: RiskLevel; count: number }>
+    userActivity: Array<{ date: string; activeUsers: number }>
+    systemHealth: {
+      database: string
+      storage: string
+      notifications: string
+    }
+  }
+}
+
+export interface ComplianceReportData {
+  compliance: {
+    totalDocuments: number
+    compliantDocuments: number
+    nonCompliantDocuments: number
+    pendingReview: number
+    complianceRate: number
+  }
+  violations: Array<{
+    documentId: string
+    documentName: string
+    violationType: string
+    severity: string
+    description: string
+    detectedAt: Date
+    status: string
+  }>
+  recommendations: Array<{
+    category: string
+    priority: string
+    description: string
+    actionRequired: string
+  }>
+}

--- a/backend/src/reporting/processors/report.processor.ts
+++ b/backend/src/reporting/processors/report.processor.ts
@@ -1,0 +1,52 @@
+import { Processor, Process } from "@nestjs/bull"
+import type { Job } from "bull"
+import { Injectable, Logger } from "@nestjs/common"
+import type { ReportingService } from "../reporting.service"
+
+@Injectable()
+@Processor("report")
+export class ReportProcessor {
+  private readonly logger = new Logger(ReportProcessor.name)
+
+  constructor(private readonly reportingService: ReportingService) {}
+
+  @Process("generate-report")
+  async handleGenerateReport(job: Job<{ reportId: string }>) {
+    const { reportId } = job.data
+    this.logger.log(`Processing report generation job for report: ${reportId}`)
+
+    try {
+      await this.reportingService.processReportGeneration(reportId)
+      this.logger.log(`Successfully generated report: ${reportId}`)
+    } catch (error) {
+      this.logger.error(`Failed to generate report ${reportId}:`, error)
+      throw error
+    }
+  }
+
+  @Process("cleanup-expired")
+  async handleCleanupExpired(job: Job) {
+    this.logger.log("Processing expired reports cleanup job")
+
+    try {
+      const deletedCount = await this.reportingService.cleanupExpiredReports()
+      this.logger.log(`Cleaned up ${deletedCount} expired reports`)
+    } catch (error) {
+      this.logger.error("Failed to cleanup expired reports:", error)
+      throw error
+    }
+  }
+
+  @Process("retry-failed")
+  async handleRetryFailed(job: Job) {
+    this.logger.log("Processing failed reports retry job")
+
+    try {
+      const retryCount = await this.reportingService.retryFailedReports()
+      this.logger.log(`Queued ${retryCount} failed reports for retry`)
+    } catch (error) {
+      this.logger.error("Failed to retry failed reports:", error)
+      throw error
+    }
+  }
+}

--- a/backend/src/reporting/reporting.controller.spec.ts
+++ b/backend/src/reporting/reporting.controller.spec.ts
@@ -1,0 +1,205 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import type { Response } from "express"
+import { ReportingController } from "./reporting.controller"
+import { ReportingService } from "./reporting.service"
+import { AdminGuard } from "../admin/guards/admin.guard"
+import { ReportType, ReportFormat, ReportStatus } from "./entities/report.entity"
+import type { GenerateReportDto } from "./dto/generate-report.dto"
+import type { ReportQueryDto } from "./dto/report-query.dto"
+import { jest } from "@jest/globals"
+
+describe("ReportingController", () => {
+  let controller: ReportingController
+  let service: ReportingService
+
+  const mockReport = {
+    id: "report-123",
+    type: ReportType.DOCUMENT_ANALYSIS,
+    format: ReportFormat.PDF,
+    status: ReportStatus.COMPLETED,
+    title: "Document Analysis Report",
+    description: "Analysis of uploaded documents",
+    parameters: {},
+    generatedBy: "admin-123",
+    generatedByEmail: "admin@example.com",
+    filePath: "/path/to/report.pdf",
+    fileName: "report.pdf",
+    fileSize: 1024,
+    downloadUrl: "/api/reports/report-123/download",
+    expiresAt: new Date(),
+    downloadCount: 0,
+    errorMessage: null,
+    metadata: {},
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+
+  const mockReportingService = {
+    generateReport: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    downloadReport: jest.fn(),
+    deleteReport: jest.fn(),
+    getReportStatistics: jest.fn(),
+    cleanupExpiredReports: jest.fn(),
+    retryFailedReports: jest.fn(),
+  }
+
+  const mockAdminGuard = {
+    canActivate: jest.fn().mockReturnValue(true),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReportingController],
+      providers: [
+        {
+          provide: ReportingService,
+          useValue: mockReportingService,
+        },
+        {
+          provide: AdminGuard,
+          useValue: mockAdminGuard,
+        },
+      ],
+    }).compile()
+
+    controller = module.get<ReportingController>(ReportingController)
+    service = module.get<ReportingService>(ReportingService)
+
+    jest.clearAllMocks()
+  })
+
+  describe("generateReport", () => {
+    it("should generate a report", async () => {
+      const generateDto: GenerateReportDto = {
+        type: ReportType.DOCUMENT_ANALYSIS,
+        format: ReportFormat.PDF,
+        title: "Test Report",
+        description: "Test description",
+        generatedBy: "admin-123",
+        generatedByEmail: "admin@example.com",
+      }
+
+      mockReportingService.generateReport.mockResolvedValue(mockReport)
+
+      const result = await controller.generateReport(generateDto)
+
+      expect(service.generateReport).toHaveBeenCalledWith(generateDto)
+      expect(result).toEqual(mockReport)
+    })
+  })
+
+  describe("findAll", () => {
+    it("should return paginated reports", async () => {
+      const query: ReportQueryDto = {
+        type: ReportType.DOCUMENT_ANALYSIS,
+        limit: 10,
+        offset: 0,
+      }
+
+      const response = {
+        reports: [mockReport],
+        total: 1,
+        limit: 10,
+        offset: 0,
+      }
+
+      mockReportingService.findAll.mockResolvedValue(response)
+
+      const result = await controller.findAll(query)
+
+      expect(service.findAll).toHaveBeenCalledWith(query)
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe("findOne", () => {
+    it("should return a specific report", async () => {
+      mockReportingService.findOne.mockResolvedValue(mockReport)
+
+      const result = await controller.findOne("report-123")
+
+      expect(service.findOne).toHaveBeenCalledWith("report-123")
+      expect(result).toEqual(mockReport)
+    })
+  })
+
+  describe("downloadReport", () => {
+    it("should download a report", async () => {
+      const mockResponse = {
+        set: jest.fn(),
+        send: jest.fn(),
+      } as unknown as Response
+
+      const buffer = Buffer.from("test report content")
+      mockReportingService.downloadReport.mockResolvedValue({
+        buffer,
+        report: mockReport,
+      })
+
+      await controller.downloadReport("report-123", mockResponse)
+
+      expect(service.downloadReport).toHaveBeenCalledWith("report-123")
+      expect(mockResponse.set).toHaveBeenCalledWith({
+        "Content-Type": "application/pdf",
+        "Content-Disposition": 'attachment; filename="report.pdf"',
+        "Content-Length": "1024",
+      })
+      expect(mockResponse.send).toHaveBeenCalledWith(buffer)
+    })
+  })
+
+  describe("deleteReport", () => {
+    it("should delete a report", async () => {
+      mockReportingService.deleteReport.mockResolvedValue(undefined)
+
+      const result = await controller.deleteReport("report-123")
+
+      expect(service.deleteReport).toHaveBeenCalledWith("report-123")
+      expect(result).toEqual({ message: "Report deleted successfully" })
+    })
+  })
+
+  describe("getStatistics", () => {
+    it("should return report statistics", async () => {
+      const stats = {
+        total: 100,
+        byType: { DOCUMENT_ANALYSIS: 50, RISK_SUMMARY: 30 },
+        byFormat: { PDF: 70, CSV: 30 },
+        byStatus: { COMPLETED: 80, PENDING: 15, FAILED: 5 },
+        totalDownloads: 250,
+        averageFileSize: 2048,
+      }
+
+      mockReportingService.getReportStatistics.mockResolvedValue(stats)
+
+      const result = await controller.getStatistics("admin-123")
+
+      expect(service.getReportStatistics).toHaveBeenCalledWith("admin-123")
+      expect(result).toEqual(stats)
+    })
+  })
+
+  describe("cleanupExpiredReports", () => {
+    it("should cleanup expired reports", async () => {
+      mockReportingService.cleanupExpiredReports.mockResolvedValue(5)
+
+      const result = await controller.cleanupExpiredReports()
+
+      expect(service.cleanupExpiredReports).toHaveBeenCalled()
+      expect(result).toEqual({ message: "Expired reports cleaned up", deletedCount: 5 })
+    })
+  })
+
+  describe("retryFailedReports", () => {
+    it("should retry failed reports", async () => {
+      mockReportingService.retryFailedReports.mockResolvedValue(3)
+
+      const result = await controller.retryFailedReports()
+
+      expect(service.retryFailedReports).toHaveBeenCalled()
+      expect(result).toEqual({ message: "Failed reports queued for retry", retryCount: 3 })
+    })
+  })
+})

--- a/backend/src/reporting/reporting.controller.ts
+++ b/backend/src/reporting/reporting.controller.ts
@@ -1,0 +1,87 @@
+import { Controller, Get, Post, Param, Query, Res, Delete, ParseUUIDPipe, UseGuards } from "@nestjs/common"
+import type { Response } from "express"
+import type { ReportingService } from "./reporting.service"
+import type { GenerateReportDto } from "./dto/generate-report.dto"
+import type { ReportQueryDto } from "./dto/report-query.dto"
+import type { Report } from "./entities/report.entity"
+import { AdminGuard, Roles } from "../admin/guards/admin.guard"
+import { UserRole } from "../admin/entities/user.entity"
+
+@Controller("reports")
+@UseGuards(AdminGuard)
+@Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.MODERATOR)
+export class ReportingController {
+  constructor(private readonly reportingService: ReportingService) {}
+
+  @Post("generate")
+  async generateReport(generateReportDto: GenerateReportDto): Promise<Report> {
+    return await this.reportingService.generateReport(generateReportDto)
+  }
+
+  @Get()
+  async findAll(query: ReportQueryDto): Promise<{
+    reports: Report[]
+    total: number
+    limit: number
+    offset: number
+  }> {
+    return await this.reportingService.findAll(query)
+  }
+
+  @Get("statistics")
+  async getStatistics(@Query("generatedBy") generatedBy?: string): Promise<{
+    total: number
+    byType: Record<string, number>
+    byFormat: Record<string, number>
+    byStatus: Record<string, number>
+    totalDownloads: number
+    averageFileSize: number
+  }> {
+    return await this.reportingService.getReportStatistics(generatedBy)
+  }
+
+  @Get(":id")
+  async findOne(@Param("id", ParseUUIDPipe) id: string): Promise<Report> {
+    return await this.reportingService.findOne(id)
+  }
+
+  @Get(":id/download")
+  async downloadReport(@Param("id", ParseUUIDPipe) id: string, @Res() res: Response): Promise<void> {
+    const { buffer, report } = await this.reportingService.downloadReport(id)
+
+    const mimeTypes = {
+      PDF: "application/pdf",
+      CSV: "text/csv",
+      EXCEL: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      JSON: "application/json",
+    }
+
+    res.set({
+      "Content-Type": mimeTypes[report.format] || "application/octet-stream",
+      "Content-Disposition": `attachment; filename="${report.fileName}"`,
+      "Content-Length": report.fileSize.toString(),
+    })
+
+    res.send(buffer)
+  }
+
+  @Delete(":id")
+  async deleteReport(@Param("id", ParseUUIDPipe) id: string): Promise<{ message: string }> {
+    await this.reportingService.deleteReport(id)
+    return { message: "Report deleted successfully" }
+  }
+
+  @Post("cleanup-expired")
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  async cleanupExpiredReports(): Promise<{ message: string; deletedCount: number }> {
+    const deletedCount = await this.reportingService.cleanupExpiredReports()
+    return { message: "Expired reports cleaned up", deletedCount }
+  }
+
+  @Post("retry-failed")
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  async retryFailedReports(): Promise<{ message: string; retryCount: number }> {
+    const retryCount = await this.reportingService.retryFailedReports()
+    return { message: "Failed reports queued for retry", retryCount }
+  }
+}

--- a/backend/src/reporting/reporting.module.ts
+++ b/backend/src/reporting/reporting.module.ts
@@ -1,0 +1,33 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { BullModule } from "@nestjs/bull"
+import { ReportingController } from "./reporting.controller"
+import { ReportingService } from "./reporting.service"
+import { Report } from "./entities/report.entity"
+import { DataAggregatorService } from "./services/data-aggregator.service"
+import { PdfGeneratorService } from "./services/pdf-generator.service"
+import { CsvGeneratorService } from "./services/csv-generator.service"
+import { ReportProcessor } from "./processors/report.processor"
+import { Document } from "../documents/entities/document.entity"
+import { RiskAnalysis } from "../risk-analysis/entities/risk-analysis.entity"
+import { AuditLog } from "../audit-log/entities/audit-log.entity"
+import { User } from "../admin/entities/user.entity"
+import { Notification } from "../notification/entities/notification.entity"
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Report, Document, RiskAnalysis, AuditLog, User, Notification]),
+    BullModule.registerQueue({
+      name: "report",
+      redis: {
+        host: process.env.REDIS_HOST || "localhost",
+        port: Number.parseInt(process.env.REDIS_PORT || "6379"),
+        password: process.env.REDIS_PASSWORD,
+      },
+    }),
+  ],
+  controllers: [ReportingController],
+  providers: [ReportingService, DataAggregatorService, PdfGeneratorService, CsvGeneratorService, ReportProcessor],
+  exports: [ReportingService],
+})
+export class ReportingModule {}

--- a/backend/src/reporting/reporting.service.spec.ts
+++ b/backend/src/reporting/reporting.service.spec.ts
@@ -1,0 +1,411 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { getQueueToken } from "@nestjs/bull"
+import type { Repository } from "typeorm"
+import type { Queue } from "bull"
+import { ReportingService } from "./reporting.service"
+import { Report, ReportType, ReportFormat, ReportStatus } from "./entities/report.entity"
+import { DataAggregatorService } from "./services/data-aggregator.service"
+import { PdfGeneratorService } from "./services/pdf-generator.service"
+import { CsvGeneratorService } from "./services/csv-generator.service"
+import type { GenerateReportDto } from "./dto/generate-report.dto"
+import type { ReportQueryDto } from "./dto/report-query.dto"
+import * as fs from "fs"
+import { jest } from "@jest/globals"
+
+// Mock fs module
+jest.mock("fs")
+const mockedFs = fs as jest.Mocked<typeof fs>
+
+describe("ReportingService", () => {
+  let service: ReportingService
+  let repository: Repository<Report>
+  let queue: Queue
+
+  const mockReport: Report = {
+    id: "report-123",
+    type: ReportType.DOCUMENT_ANALYSIS,
+    format: ReportFormat.PDF,
+    status: ReportStatus.PENDING,
+    title: "Document Analysis Report",
+    description: "Analysis of uploaded documents",
+    parameters: {
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+    },
+    generatedBy: "admin-123",
+    generatedByEmail: "admin@example.com",
+    filePath: null,
+    fileName: null,
+    fileSize: 0,
+    downloadUrl: null,
+    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    downloadCount: 0,
+    errorMessage: null,
+    metadata: {},
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+
+  const mockRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    findAndCount: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    increment: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  }
+
+  const mockQueue = {
+    add: jest.fn(),
+  }
+
+  const mockDataAggregatorService = {
+    aggregateDocumentAnalysisData: jest.fn(),
+    aggregateRiskSummaryData: jest.fn(),
+    aggregateAuditTrailData: jest.fn(),
+    aggregateUserActivityData: jest.fn(),
+    aggregateSystemOverviewData: jest.fn(),
+    aggregateComplianceData: jest.fn(),
+  }
+
+  const mockPdfGeneratorService = {
+    generateDocumentAnalysisReport: jest.fn(),
+    generateRiskSummaryReport: jest.fn(),
+    generateAuditTrailReport: jest.fn(),
+    generateUserActivityReport: jest.fn(),
+    generateSystemOverviewReport: jest.fn(),
+    generateComplianceReport: jest.fn(),
+  }
+
+  const mockCsvGeneratorService = {
+    generateDocumentAnalysisReport: jest.fn(),
+    generateRiskSummaryReport: jest.fn(),
+    generateAuditTrailReport: jest.fn(),
+    generateUserActivityReport: jest.fn(),
+    generateSystemOverviewReport: jest.fn(),
+    generateComplianceReport: jest.fn(),
+  }
+
+  const mockQueryBuilder = {
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportingService,
+        {
+          provide: getRepositoryToken(Report),
+          useValue: mockRepository,
+        },
+        {
+          provide: getQueueToken("report"),
+          useValue: mockQueue,
+        },
+        {
+          provide: DataAggregatorService,
+          useValue: mockDataAggregatorService,
+        },
+        {
+          provide: PdfGeneratorService,
+          useValue: mockPdfGeneratorService,
+        },
+        {
+          provide: CsvGeneratorService,
+          useValue: mockCsvGeneratorService,
+        },
+      ],
+    }).compile()
+
+    service = module.get<ReportingService>(ReportingService)
+    repository = module.get<Repository<Report>>(getRepositoryToken(Report))
+    queue = module.get<Queue>(getQueueToken("report"))
+
+    jest.clearAllMocks()
+    mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+
+    // Mock fs methods
+    mockedFs.existsSync.mockReturnValue(true)
+    mockedFs.mkdirSync.mockReturnValue(undefined)
+    mockedFs.readFileSync.mockReturnValue(Buffer.from("test report content"))
+    mockedFs.unlinkSync.mockReturnValue(undefined)
+    mockedFs.statSync.mockReturnValue({ size: 1024 } as any)
+  })
+
+  describe("generateReport", () => {
+    it("should create and queue a report for generation", async () => {
+      const generateDto: GenerateReportDto = {
+        type: ReportType.DOCUMENT_ANALYSIS,
+        format: ReportFormat.PDF,
+        title: "Test Report",
+        description: "Test description",
+        generatedBy: "admin-123",
+        generatedByEmail: "admin@example.com",
+        startDate: "2024-01-01",
+        endDate: "2024-01-31",
+      }
+
+      mockRepository.create.mockReturnValue(mockReport)
+      mockRepository.save.mockResolvedValue(mockReport)
+      mockQueue.add.mockResolvedValue({})
+
+      const result = await service.generateReport(generateDto)
+
+      expect(repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: generateDto.type,
+          format: generateDto.format,
+          title: generateDto.title,
+          status: ReportStatus.PENDING,
+        }),
+      )
+      expect(repository.save).toHaveBeenCalledWith(mockReport)
+      expect(queue.add).toHaveBeenCalledWith(
+        "generate-report",
+        { reportId: mockReport.id },
+        expect.objectContaining({
+          attempts: 3,
+          backoff: expect.any(Object),
+        }),
+      )
+      expect(result).toEqual(mockReport)
+    })
+  })
+
+  describe("processReportGeneration", () => {
+    it("should process document analysis report generation", async () => {
+      const completedReport = { ...mockReport, status: ReportStatus.GENERATING }
+      mockRepository.findOne.mockResolvedValue(completedReport)
+      mockRepository.update.mockResolvedValue({})
+
+      const mockData = {
+        documents: [],
+        summary: {
+          totalDocuments: 0,
+          byRiskLevel: {},
+          byMimeType: {},
+          averageRiskScore: 0,
+          totalSize: 0,
+        },
+      }
+
+      mockDataAggregatorService.aggregateDocumentAnalysisData.mockResolvedValue(mockData)
+      mockPdfGeneratorService.generateDocumentAnalysisReport.mockResolvedValue(undefined)
+
+      await service.processReportGeneration("report-123")
+
+      expect(mockDataAggregatorService.aggregateDocumentAnalysisData).toHaveBeenCalled()
+      expect(mockPdfGeneratorService.generateDocumentAnalysisReport).toHaveBeenCalledWith(
+        mockData,
+        completedReport.title,
+        expect.any(String),
+      )
+      expect(repository.update).toHaveBeenCalledWith(
+        "report-123",
+        expect.objectContaining({
+          status: ReportStatus.COMPLETED,
+          filePath: expect.any(String),
+          fileName: expect.any(String),
+          fileSize: 1024,
+        }),
+      )
+    })
+
+    it("should handle CSV format generation", async () => {
+      const csvReport = { ...mockReport, format: ReportFormat.CSV, status: ReportStatus.GENERATING }
+      mockRepository.findOne.mockResolvedValue(csvReport)
+      mockRepository.update.mockResolvedValue({})
+
+      const mockData = {
+        documents: [],
+        summary: {
+          totalDocuments: 0,
+          byRiskLevel: {},
+          byMimeType: {},
+          averageRiskScore: 0,
+          totalSize: 0,
+        },
+      }
+
+      mockDataAggregatorService.aggregateDocumentAnalysisData.mockResolvedValue(mockData)
+      mockCsvGeneratorService.generateDocumentAnalysisReport.mockResolvedValue(undefined)
+
+      await service.processReportGeneration("report-123")
+
+      expect(mockCsvGeneratorService.generateDocumentAnalysisReport).toHaveBeenCalledWith(mockData, expect.any(String))
+    })
+
+    it("should handle generation errors", async () => {
+      mockRepository.findOne.mockResolvedValue(mockReport)
+      mockRepository.update.mockResolvedValue({})
+      mockDataAggregatorService.aggregateDocumentAnalysisData.mockRejectedValue(new Error("Data aggregation failed"))
+
+      await expect(service.processReportGeneration("report-123")).rejects.toThrow("Data aggregation failed")
+
+      expect(repository.update).toHaveBeenCalledWith(
+        "report-123",
+        expect.objectContaining({
+          status: ReportStatus.FAILED,
+          errorMessage: "Data aggregation failed",
+        }),
+      )
+    })
+  })
+
+  describe("findAll", () => {
+    it("should return paginated reports", async () => {
+      const query: ReportQueryDto = {
+        type: ReportType.DOCUMENT_ANALYSIS,
+        limit: 10,
+        offset: 0,
+      }
+
+      const reports = [mockReport]
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([reports, 1])
+
+      const result = await service.findAll(query)
+
+      expect(repository.createQueryBuilder).toHaveBeenCalledWith("report")
+      expect(result).toEqual({
+        reports,
+        total: 1,
+        limit: 10,
+        offset: 0,
+      })
+    })
+
+    it("should handle search query", async () => {
+      const query: ReportQueryDto = {
+        search: "analysis",
+        limit: 50,
+        offset: 0,
+      }
+
+      const reports = [mockReport]
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([reports, 1])
+
+      const result = await service.findAll(query)
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        "(report.title ILIKE :search OR report.description ILIKE :search)",
+        { search: "%analysis%" },
+      )
+      expect(result.reports).toEqual(reports)
+    })
+  })
+
+  describe("downloadReport", () => {
+    it("should return report buffer for completed report", async () => {
+      const completedReport = {
+        ...mockReport,
+        status: ReportStatus.COMPLETED,
+        filePath: "/path/to/report.pdf",
+        fileName: "report.pdf",
+        fileSize: 1024,
+      }
+
+      mockRepository.findOne.mockResolvedValue(completedReport)
+      mockRepository.increment.mockResolvedValue({})
+
+      const result = await service.downloadReport("report-123")
+
+      expect(fs.readFileSync).toHaveBeenCalledWith(completedReport.filePath)
+      expect(repository.increment).toHaveBeenCalledWith({ id: "report-123" }, "downloadCount", 1)
+      expect(result.buffer).toBeInstanceOf(Buffer)
+      expect(result.report).toEqual(completedReport)
+    })
+
+    it("should throw error for non-completed report", async () => {
+      mockRepository.findOne.mockResolvedValue(mockReport)
+
+      await expect(service.downloadReport("report-123")).rejects.toThrow("Report is not ready for download")
+    })
+
+    it("should throw error for expired report", async () => {
+      const expiredReport = {
+        ...mockReport,
+        status: ReportStatus.COMPLETED,
+        expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000), // Yesterday
+      }
+
+      mockRepository.findOne.mockResolvedValue(expiredReport)
+
+      await expect(service.downloadReport("report-123")).rejects.toThrow("Report has expired")
+    })
+  })
+
+  describe("getReportStatistics", () => {
+    it("should return report statistics", async () => {
+      const reports = [
+        mockReport,
+        { ...mockReport, id: "report-124", type: ReportType.RISK_SUMMARY, downloadCount: 5, fileSize: 2048 },
+      ]
+      mockRepository.find.mockResolvedValue(reports)
+
+      const result = await service.getReportStatistics()
+
+      expect(result.total).toBe(2)
+      expect(result.byType[ReportType.DOCUMENT_ANALYSIS]).toBe(1)
+      expect(result.byType[ReportType.RISK_SUMMARY]).toBe(1)
+      expect(result.totalDownloads).toBe(5)
+      expect(result.averageFileSize).toBe(1024) // (0 + 2048) / 2
+    })
+  })
+
+  describe("cleanupExpiredReports", () => {
+    it("should cleanup expired reports", async () => {
+      const expiredReports = [
+        {
+          ...mockReport,
+          id: "expired-1",
+          status: ReportStatus.COMPLETED,
+          expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          filePath: "/path/to/expired1.pdf",
+        },
+        {
+          ...mockReport,
+          id: "expired-2",
+          status: ReportStatus.COMPLETED,
+          expiresAt: new Date(Date.now() - 48 * 60 * 60 * 1000),
+          filePath: "/path/to/expired2.pdf",
+        },
+      ]
+
+      mockRepository.find.mockResolvedValue(expiredReports)
+      mockRepository.update.mockResolvedValue({})
+
+      const result = await service.cleanupExpiredReports()
+
+      expect(fs.unlinkSync).toHaveBeenCalledTimes(2)
+      expect(repository.update).toHaveBeenCalledTimes(2)
+      expect(result).toBe(2)
+    })
+  })
+
+  describe("retryFailedReports", () => {
+    it("should retry failed reports", async () => {
+      const failedReports = [
+        { ...mockReport, id: "failed-1", status: ReportStatus.FAILED },
+        { ...mockReport, id: "failed-2", status: ReportStatus.FAILED },
+      ]
+
+      mockRepository.find.mockResolvedValue(failedReports)
+      mockRepository.update.mockResolvedValue({})
+      mockQueue.add.mockResolvedValue({})
+
+      const result = await service.retryFailedReports()
+
+      expect(repository.update).toHaveBeenCalledTimes(2)
+      expect(queue.add).toHaveBeenCalledTimes(2)
+      expect(result).toBe(2)
+    })
+  })
+})

--- a/backend/src/reporting/reporting.service.ts
+++ b/backend/src/reporting/reporting.service.ts
@@ -1,0 +1,416 @@
+import { Injectable, Logger, NotFoundException, BadRequestException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import { Between } from "typeorm"
+import type { Queue } from "bull"
+import type { Report } from "./entities/report.entity"
+import { ReportStatus, ReportType, ReportFormat } from "./entities/report.entity"
+import type { GenerateReportDto } from "./dto/generate-report.dto"
+import type { ReportQueryDto } from "./dto/report-query.dto"
+import type { DataAggregatorService } from "./services/data-aggregator.service"
+import type { PdfGeneratorService } from "./services/pdf-generator.service"
+import type { CsvGeneratorService } from "./services/csv-generator.service"
+import * as fs from "fs"
+import * as path from "path"
+
+@Injectable()
+export class ReportingService {
+  private readonly logger = new Logger(ReportingService.name)
+  private readonly reportsPath = "./uploads/reports"
+
+  constructor(
+    private reportRepository: Repository<Report>,
+    private dataAggregatorService: DataAggregatorService,
+    private pdfGeneratorService: PdfGeneratorService,
+    private csvGeneratorService: CsvGeneratorService,
+    private reportQueue: Queue,
+  ) {
+    // Ensure reports directory exists
+    if (!fs.existsSync(this.reportsPath)) {
+      fs.mkdirSync(this.reportsPath, { recursive: true })
+    }
+  }
+
+  async generateReport(generateReportDto: GenerateReportDto): Promise<Report> {
+    this.logger.log(`Generating report: ${generateReportDto.title}`)
+
+    // Create report record
+    const report = this.reportRepository.create({
+      type: generateReportDto.type,
+      format: generateReportDto.format,
+      title: generateReportDto.title,
+      description: generateReportDto.description,
+      parameters: {
+        startDate: generateReportDto.startDate,
+        endDate: generateReportDto.endDate,
+        documentIds: generateReportDto.documentIds,
+        userIds: generateReportDto.userIds,
+        riskLevel: generateReportDto.riskLevel,
+        department: generateReportDto.department,
+        additionalFilters: generateReportDto.additionalFilters,
+      },
+      generatedBy: generateReportDto.generatedBy,
+      generatedByEmail: generateReportDto.generatedByEmail,
+      status: ReportStatus.PENDING,
+      metadata: generateReportDto.metadata,
+      expiresAt: this.calculateExpirationDate(),
+    })
+
+    const savedReport = await this.reportRepository.save(report)
+
+    // Queue report generation
+    await this.reportQueue.add(
+      "generate-report",
+      { reportId: savedReport.id },
+      {
+        attempts: 3,
+        backoff: {
+          type: "exponential",
+          delay: 5000,
+        },
+      },
+    )
+
+    return savedReport
+  }
+
+  async processReportGeneration(reportId: string): Promise<void> {
+    const report = await this.reportRepository.findOne({ where: { id: reportId } })
+    if (!report) {
+      throw new NotFoundException(`Report ${reportId} not found`)
+    }
+
+    try {
+      // Update status to generating
+      await this.updateReportStatus(reportId, ReportStatus.GENERATING)
+
+      // Generate file name and path
+      const fileName = `${report.type.toLowerCase()}_${Date.now()}.${report.format.toLowerCase()}`
+      const filePath = path.join(this.reportsPath, fileName)
+
+      // Generate report based on type
+      await this.generateReportByType(report, filePath)
+
+      // Update report with file information
+      const fileStats = fs.statSync(filePath)
+      await this.reportRepository.update(reportId, {
+        status: ReportStatus.COMPLETED,
+        filePath,
+        fileName,
+        fileSize: fileStats.size,
+        downloadUrl: `/api/reports/${reportId}/download`,
+      })
+
+      this.logger.log(`Report generated successfully: ${fileName}`)
+    } catch (error) {
+      this.logger.error(`Failed to generate report ${reportId}:`, error)
+      await this.updateReportStatus(reportId, ReportStatus.FAILED, error.message)
+      throw error
+    }
+  }
+
+  private async generateReportByType(report: Report, filePath: string): Promise<void> {
+    const filters = {
+      startDate: report.parameters.startDate ? new Date(report.parameters.startDate) : undefined,
+      endDate: report.parameters.endDate ? new Date(report.parameters.endDate) : undefined,
+      documentIds: report.parameters.documentIds,
+      userIds: report.parameters.userIds,
+      riskLevel: report.parameters.riskLevel,
+      department: report.parameters.department,
+      ...report.parameters.additionalFilters,
+    }
+
+    switch (report.type) {
+      case ReportType.DOCUMENT_ANALYSIS:
+        const docData = await this.dataAggregatorService.aggregateDocumentAnalysisData(filters)
+        if (report.format === ReportFormat.PDF) {
+          await this.pdfGeneratorService.generateDocumentAnalysisReport(docData, report.title, filePath)
+        } else if (report.format === ReportFormat.CSV) {
+          await this.csvGeneratorService.generateDocumentAnalysisReport(docData, filePath)
+        }
+        break
+
+      case ReportType.RISK_SUMMARY:
+        const riskData = await this.dataAggregatorService.aggregateRiskSummaryData(filters)
+        if (report.format === ReportFormat.PDF) {
+          await this.pdfGeneratorService.generateRiskSummaryReport(riskData, report.title, filePath)
+        } else if (report.format === ReportFormat.CSV) {
+          await this.csvGeneratorService.generateRiskSummaryReport(riskData, filePath)
+        }
+        break
+
+      case ReportType.AUDIT_TRAIL:
+        const auditData = await this.dataAggregatorService.aggregateAuditTrailData(filters)
+        if (report.format === ReportFormat.PDF) {
+          await this.pdfGeneratorService.generateAuditTrailReport(auditData, report.title, filePath)
+        } else if (report.format === ReportFormat.CSV) {
+          await this.csvGeneratorService.generateAuditTrailReport(auditData, filePath)
+        }
+        break
+
+      case ReportType.USER_ACTIVITY:
+        const userData = await this.dataAggregatorService.aggregateUserActivityData(filters)
+        if (report.format === ReportFormat.PDF) {
+          await this.pdfGeneratorService.generateUserActivityReport(userData, report.title, filePath)
+        } else if (report.format === ReportFormat.CSV) {
+          await this.csvGeneratorService.generateUserActivityReport(userData, filePath)
+        }
+        break
+
+      case ReportType.SYSTEM_OVERVIEW:
+        const systemData = await this.dataAggregatorService.aggregateSystemOverviewData()
+        if (report.format === ReportFormat.PDF) {
+          await this.pdfGeneratorService.generateSystemOverviewReport(systemData, report.title, filePath)
+        } else if (report.format === ReportFormat.CSV) {
+          await this.csvGeneratorService.generateSystemOverviewReport(systemData, filePath)
+        }
+        break
+
+      case ReportType.COMPLIANCE:
+        const complianceData = await this.dataAggregatorService.aggregateComplianceData(filters)
+        if (report.format === ReportFormat.PDF) {
+          await this.pdfGeneratorService.generateComplianceReport(complianceData, report.title, filePath)
+        } else if (report.format === ReportFormat.CSV) {
+          await this.csvGeneratorService.generateComplianceReport(complianceData, filePath)
+        }
+        break
+
+      default:
+        throw new BadRequestException(`Unsupported report type: ${report.type}`)
+    }
+  }
+
+  async findAll(query: ReportQueryDto): Promise<{
+    reports: Report[]
+    total: number
+    limit: number
+    offset: number
+  }> {
+    const { type, format, status, generatedBy, startDate, endDate, limit = 50, offset = 0, search } = query
+
+    const whereConditions: any = {}
+
+    if (type) {
+      whereConditions.type = type
+    }
+
+    if (format) {
+      whereConditions.format = format
+    }
+
+    if (status) {
+      whereConditions.status = status
+    }
+
+    if (generatedBy) {
+      whereConditions.generatedBy = generatedBy
+    }
+
+    if (startDate && endDate) {
+      whereConditions.createdAt = Between(new Date(startDate), new Date(endDate))
+    }
+
+    let queryBuilder = this.reportRepository.createQueryBuilder("report")
+
+    // Apply where conditions
+    Object.entries(whereConditions).forEach(([key, value]) => {
+      if (key === "createdAt") {
+        queryBuilder = queryBuilder.andWhere(`report.${key} BETWEEN :startDate AND :endDate`, {
+          startDate: value.from,
+          endDate: value.to,
+        })
+      } else {
+        queryBuilder = queryBuilder.andWhere(`report.${key} = :${key}`, { [key]: value })
+      }
+    })
+
+    // Apply search
+    if (search) {
+      queryBuilder = queryBuilder.andWhere("(report.title ILIKE :search OR report.description ILIKE :search)", {
+        search: `%${search}%`,
+      })
+    }
+
+    // Apply pagination and ordering
+    queryBuilder = queryBuilder.orderBy("report.createdAt", "DESC").take(limit).skip(offset)
+
+    const [reports, total] = await queryBuilder.getManyAndCount()
+
+    return {
+      reports,
+      total,
+      limit,
+      offset,
+    }
+  }
+
+  async findOne(id: string): Promise<Report> {
+    const report = await this.reportRepository.findOne({ where: { id } })
+    if (!report) {
+      throw new NotFoundException(`Report with ID ${id} not found`)
+    }
+    return report
+  }
+
+  async downloadReport(id: string): Promise<{ buffer: Buffer; report: Report }> {
+    const report = await this.findOne(id)
+
+    if (report.status !== ReportStatus.COMPLETED) {
+      throw new BadRequestException("Report is not ready for download")
+    }
+
+    if (!report.filePath || !fs.existsSync(report.filePath)) {
+      throw new NotFoundException("Report file not found")
+    }
+
+    // Check if report has expired
+    if (report.expiresAt && report.expiresAt < new Date()) {
+      throw new BadRequestException("Report has expired")
+    }
+
+    // Increment download count
+    await this.reportRepository.increment({ id }, "downloadCount", 1)
+
+    const buffer = fs.readFileSync(report.filePath)
+    return { buffer, report }
+  }
+
+  async deleteReport(id: string): Promise<void> {
+    const report = await this.findOne(id)
+
+    // Delete file if it exists
+    if (report.filePath && fs.existsSync(report.filePath)) {
+      fs.unlinkSync(report.filePath)
+    }
+
+    // Delete from database
+    await this.reportRepository.remove(report)
+  }
+
+  async getReportStatistics(generatedBy?: string): Promise<{
+    total: number
+    byType: Record<string, number>
+    byFormat: Record<string, number>
+    byStatus: Record<string, number>
+    totalDownloads: number
+    averageFileSize: number
+  }> {
+    const whereCondition: any = {}
+    if (generatedBy) {
+      whereCondition.generatedBy = generatedBy
+    }
+
+    const reports = await this.reportRepository.find({ where: whereCondition })
+
+    const stats = {
+      total: reports.length,
+      byType: {} as Record<string, number>,
+      byFormat: {} as Record<string, number>,
+      byStatus: {} as Record<string, number>,
+      totalDownloads: 0,
+      averageFileSize: 0,
+    }
+
+    let totalFileSize = 0
+
+    reports.forEach((report) => {
+      // Count by type
+      stats.byType[report.type] = (stats.byType[report.type] || 0) + 1
+
+      // Count by format
+      stats.byFormat[report.format] = (stats.byFormat[report.format] || 0) + 1
+
+      // Count by status
+      stats.byStatus[report.status] = (stats.byStatus[report.status] || 0) + 1
+
+      // Sum downloads and file sizes
+      stats.totalDownloads += report.downloadCount
+      totalFileSize += report.fileSize
+    })
+
+    stats.averageFileSize = reports.length > 0 ? totalFileSize / reports.length : 0
+
+    return stats
+  }
+
+  async cleanupExpiredReports(): Promise<number> {
+    const expiredReports = await this.reportRepository.find({
+      where: {
+        expiresAt: Between(new Date("1970-01-01"), new Date()),
+        status: ReportStatus.COMPLETED,
+      },
+    })
+
+    let deletedCount = 0
+    for (const report of expiredReports) {
+      try {
+        // Delete file
+        if (report.filePath && fs.existsSync(report.filePath)) {
+          fs.unlinkSync(report.filePath)
+        }
+
+        // Update status to expired
+        await this.reportRepository.update(report.id, {
+          status: ReportStatus.EXPIRED,
+          filePath: null,
+          fileName: null,
+          fileSize: 0,
+        })
+
+        deletedCount++
+      } catch (error) {
+        this.logger.error(`Failed to cleanup expired report ${report.id}:`, error)
+      }
+    }
+
+    this.logger.log(`Cleaned up ${deletedCount} expired reports`)
+    return deletedCount
+  }
+
+  async retryFailedReports(): Promise<number> {
+    const failedReports = await this.reportRepository.find({
+      where: { status: ReportStatus.FAILED },
+    })
+
+    let retryCount = 0
+    for (const report of failedReports) {
+      try {
+        // Reset status to pending
+        await this.updateReportStatus(report.id, ReportStatus.PENDING)
+
+        // Requeue for generation
+        await this.reportQueue.add(
+          "generate-report",
+          { reportId: report.id },
+          {
+            attempts: 3,
+            backoff: {
+              type: "exponential",
+              delay: 5000,
+            },
+          },
+        )
+
+        retryCount++
+      } catch (error) {
+        this.logger.error(`Failed to retry report ${report.id}:`, error)
+      }
+    }
+
+    this.logger.log(`Queued ${retryCount} failed reports for retry`)
+    return retryCount
+  }
+
+  private async updateReportStatus(id: string, status: ReportStatus, errorMessage?: string): Promise<void> {
+    const updateData: any = { status }
+    if (errorMessage) {
+      updateData.errorMessage = errorMessage
+    }
+    await this.reportRepository.update(id, updateData)
+  }
+
+  private calculateExpirationDate(): Date {
+    const expirationDate = new Date()
+    expirationDate.setDate(expirationDate.getDate() + 30) // Reports expire after 30 days
+    return expirationDate
+  }
+}

--- a/backend/src/reporting/services/csv-generator.service.ts
+++ b/backend/src/reporting/services/csv-generator.service.ts
@@ -1,0 +1,213 @@
+import { Injectable, Logger } from "@nestjs/common"
+import * as fs from "fs"
+import type {
+  DocumentAnalysisReportData,
+  RiskSummaryReportData,
+  AuditTrailReportData,
+  UserActivityReportData,
+  SystemOverviewReportData,
+  ComplianceReportData,
+} from "../interfaces/report-data.interface"
+
+@Injectable()
+export class CsvGeneratorService {
+  private readonly logger = new Logger(CsvGeneratorService.name)
+
+  async generateDocumentAnalysisReport(data: DocumentAnalysisReportData, filePath: string): Promise<void> {
+    const headers = [
+      "Document ID",
+      "Document Name",
+      "Original Name",
+      "Uploaded By",
+      "Upload Date",
+      "Size (Bytes)",
+      "MIME Type",
+      "Risk Level",
+      "Risk Score",
+      "Risk Summary",
+      "Detected Keywords",
+      "Analyzed By",
+      "Analysis Date",
+    ]
+
+    const rows = data.documents.map((doc) => [
+      doc.id,
+      doc.name,
+      doc.originalName,
+      doc.uploadedBy,
+      doc.uploadedAt.toISOString(),
+      doc.size.toString(),
+      doc.mimeType,
+      doc.riskAnalysis?.riskLevel || "N/A",
+      doc.riskAnalysis?.riskScore?.toString() || "N/A",
+      doc.riskAnalysis?.summary || "N/A",
+      doc.riskAnalysis?.detectedKeywords.join("; ") || "N/A",
+      doc.riskAnalysis?.analyzedBy || "N/A",
+      doc.riskAnalysis?.analyzedAt?.toISOString() || "N/A",
+    ])
+
+    await this.writeCsvFile(filePath, headers, rows)
+  }
+
+  async generateRiskSummaryReport(data: RiskSummaryReportData, filePath: string): Promise<void> {
+    const headers = [
+      "Analysis ID",
+      "Document ID",
+      "Document Name",
+      "Risk Level",
+      "Risk Score",
+      "Summary",
+      "Detected Keywords",
+      "Risk Factors Count",
+      "Top Risk Category",
+      "Analyzed By",
+      "Analysis Date",
+      "Uploaded By",
+    ]
+
+    const rows = data.riskAnalyses.map((analysis) => [
+      analysis.id,
+      analysis.documentId,
+      analysis.documentName,
+      analysis.riskLevel,
+      analysis.riskScore.toString(),
+      analysis.summary,
+      analysis.detectedKeywords.join("; "),
+      analysis.riskFactors.length.toString(),
+      analysis.riskFactors[0]?.category || "N/A",
+      analysis.analyzedBy,
+      analysis.analyzedAt.toISOString(),
+      analysis.uploadedBy,
+    ])
+
+    await this.writeCsvFile(filePath, headers, rows)
+  }
+
+  async generateAuditTrailReport(data: AuditTrailReportData, filePath: string): Promise<void> {
+    const headers = [
+      "Log ID",
+      "User ID",
+      "User Email",
+      "Action",
+      "Description",
+      "Resource Type",
+      "Resource ID",
+      "Success",
+      "IP Address",
+      "Timestamp",
+    ]
+
+    const rows = data.auditLogs.map((log) => [
+      log.id,
+      log.userId,
+      log.userEmail,
+      log.action,
+      log.description,
+      log.resourceType,
+      log.resourceId,
+      log.success.toString(),
+      log.ipAddress,
+      log.createdAt.toISOString(),
+    ])
+
+    await this.writeCsvFile(filePath, headers, rows)
+  }
+
+  async generateUserActivityReport(data: UserActivityReportData, filePath: string): Promise<void> {
+    const headers = [
+      "User ID",
+      "Email",
+      "Full Name",
+      "Role",
+      "Department",
+      "Documents Uploaded",
+      "Documents Analyzed",
+      "Risk Documents",
+      "Total Actions",
+      "Last Activity",
+    ]
+
+    const rows = data.users.map((user) => [
+      user.id,
+      user.email,
+      user.fullName,
+      user.role,
+      user.department,
+      user.documentsUploaded.toString(),
+      user.documentsAnalyzed.toString(),
+      user.riskDocuments.toString(),
+      user.totalActions.toString(),
+      user.lastActivity.toISOString(),
+    ])
+
+    await this.writeCsvFile(filePath, headers, rows)
+  }
+
+  async generateSystemOverviewReport(data: SystemOverviewReportData, filePath: string): Promise<void> {
+    // System metrics as CSV
+    const headers = ["Metric", "Value", "Date"]
+
+    const rows = [
+      ["Total Documents", data.overview.totalDocuments.toString(), new Date().toISOString()],
+      ["Total Users", data.overview.totalUsers.toString(), new Date().toISOString()],
+      ["Total Risk Analyses", data.overview.totalRiskAnalyses.toString(), new Date().toISOString()],
+      ["Total Audit Logs", data.overview.totalAuditLogs.toString(), new Date().toISOString()],
+      ["Total Notifications", data.overview.totalNotifications.toString(), new Date().toISOString()],
+      ["System Uptime", data.overview.systemUptime, new Date().toISOString()],
+      ["Last Backup", data.overview.lastBackup.toISOString(), new Date().toISOString()],
+      ["Database Health", data.metrics.systemHealth.database, new Date().toISOString()],
+      ["Storage Health", data.metrics.systemHealth.storage, new Date().toISOString()],
+      ["Notifications Health", data.metrics.systemHealth.notifications, new Date().toISOString()],
+    ]
+
+    // Add daily metrics
+    data.metrics.documentsPerDay.forEach((day) => {
+      rows.push(["Documents Per Day", day.count.toString(), day.date])
+    })
+
+    data.metrics.userActivity.forEach((day) => {
+      rows.push(["Active Users", day.activeUsers.toString(), day.date])
+    })
+
+    await this.writeCsvFile(filePath, headers, rows)
+  }
+
+  async generateComplianceReport(data: ComplianceReportData, filePath: string): Promise<void> {
+    const headers = [
+      "Document ID",
+      "Document Name",
+      "Violation Type",
+      "Severity",
+      "Description",
+      "Detected Date",
+      "Status",
+    ]
+
+    const rows = data.violations.map((violation) => [
+      violation.documentId,
+      violation.documentName,
+      violation.violationType,
+      violation.severity,
+      violation.description,
+      violation.detectedAt.toISOString(),
+      violation.status,
+    ])
+
+    await this.writeCsvFile(filePath, headers, rows)
+  }
+
+  private async writeCsvFile(filePath: string, headers: string[], rows: string[][]): Promise<void> {
+    const csvContent = [headers, ...rows]
+      .map((row) => row.map((field) => this.escapeCsvField(field)).join(","))
+      .join("\n")
+
+    await fs.promises.writeFile(filePath, csvContent, "utf-8")
+  }
+
+  private escapeCsvField(field: string): string {
+    if (field.includes(",") || field.includes('"') || field.includes("\n")) {
+      return `"${field.replace(/"/g, '""')}"`
+    }
+    return field
+  }
+}

--- a/backend/src/reporting/services/data-aggregator.service.ts
+++ b/backend/src/reporting/services/data-aggregator.service.ts
@@ -1,0 +1,618 @@
+import { Injectable, Logger } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import { In } from "typeorm"
+import type { Document } from "../../documents/entities/document.entity"
+import type { RiskAnalysis } from "../../risk-analysis/entities/risk-analysis.entity"
+import { RiskLevel } from "../../risk-analysis/entities/risk-analysis.entity"
+import type { AuditLog } from "../../audit-log/entities/audit-log.entity"
+import type { User } from "../../admin/entities/user.entity"
+import type { Notification } from "../../notification/entities/notification.entity"
+import type {
+  DocumentAnalysisReportData,
+  RiskSummaryReportData,
+  AuditTrailReportData,
+  UserActivityReportData,
+  SystemOverviewReportData,
+  ComplianceReportData,
+} from "../interfaces/report-data.interface"
+
+@Injectable()
+export class DataAggregatorService {
+  private readonly logger = new Logger(DataAggregatorService.name)
+
+  constructor(
+    private documentRepository: Repository<Document>,
+    private riskAnalysisRepository: Repository<RiskAnalysis>,
+    private auditLogRepository: Repository<AuditLog>,
+    private userRepository: Repository<User>,
+    private notificationRepository: Repository<Notification>,
+  ) {}
+
+  async aggregateDocumentAnalysisData(filters: {
+    startDate?: Date
+    endDate?: Date
+    documentIds?: string[]
+    userIds?: string[]
+    riskLevel?: string
+  }): Promise<DocumentAnalysisReportData> {
+    let documentQuery = this.documentRepository.createQueryBuilder("document")
+
+    if (filters.startDate && filters.endDate) {
+      documentQuery = documentQuery.where("document.createdAt BETWEEN :startDate AND :endDate", {
+        startDate: filters.startDate,
+        endDate: filters.endDate,
+      })
+    }
+
+    if (filters.documentIds && filters.documentIds.length > 0) {
+      documentQuery = documentQuery.andWhere("document.id IN (:...documentIds)", {
+        documentIds: filters.documentIds,
+      })
+    }
+
+    if (filters.userIds && filters.userIds.length > 0) {
+      documentQuery = documentQuery.andWhere("document.uploadedBy IN (:...userIds)", {
+        userIds: filters.userIds,
+      })
+    }
+
+    const documents = await documentQuery.getMany()
+
+    // Get risk analyses for these documents
+    const riskAnalyses = await this.riskAnalysisRepository.find({
+      where: { documentId: In(documents.map((d) => d.id)) },
+    })
+
+    const riskAnalysisMap = new Map(riskAnalyses.map((ra) => [ra.documentId, ra]))
+
+    // Filter by risk level if specified
+    let filteredDocuments = documents
+    if (filters.riskLevel) {
+      filteredDocuments = documents.filter((doc) => {
+        const analysis = riskAnalysisMap.get(doc.id)
+        return analysis && analysis.riskLevel === filters.riskLevel
+      })
+    }
+
+    // Build document data with risk analysis
+    const documentData = filteredDocuments.map((doc) => ({
+      id: doc.id,
+      name: doc.name,
+      originalName: doc.originalName,
+      uploadedBy: doc.uploadedBy,
+      uploadedAt: doc.createdAt,
+      size: doc.size,
+      mimeType: doc.mimeType,
+      riskAnalysis: riskAnalysisMap.get(doc.id)
+        ? {
+            id: riskAnalysisMap.get(doc.id)!.id,
+            riskLevel: riskAnalysisMap.get(doc.id)!.riskLevel,
+            riskScore: Number(riskAnalysisMap.get(doc.id)!.riskScore),
+            summary: riskAnalysisMap.get(doc.id)!.summary,
+            detectedKeywords: riskAnalysisMap.get(doc.id)!.detectedKeywords,
+            analyzedBy: riskAnalysisMap.get(doc.id)!.analyzedBy,
+            analyzedAt: riskAnalysisMap.get(doc.id)!.createdAt,
+          }
+        : undefined,
+    }))
+
+    // Calculate summary statistics
+    const byRiskLevel = {} as Record<RiskLevel, number>
+    const byMimeType = {} as Record<string, number>
+    let totalRiskScore = 0
+    let analyzedCount = 0
+
+    documentData.forEach((doc) => {
+      // Count by MIME type
+      byMimeType[doc.mimeType] = (byMimeType[doc.mimeType] || 0) + 1
+
+      // Count by risk level and calculate average score
+      if (doc.riskAnalysis) {
+        byRiskLevel[doc.riskAnalysis.riskLevel] = (byRiskLevel[doc.riskAnalysis.riskLevel] || 0) + 1
+        totalRiskScore += doc.riskAnalysis.riskScore
+        analyzedCount++
+      }
+    })
+
+    return {
+      documents: documentData,
+      summary: {
+        totalDocuments: documentData.length,
+        byRiskLevel,
+        byMimeType,
+        averageRiskScore: analyzedCount > 0 ? totalRiskScore / analyzedCount : 0,
+        totalSize: documentData.reduce((sum, doc) => sum + doc.size, 0),
+      },
+    }
+  }
+
+  async aggregateRiskSummaryData(filters: {
+    startDate?: Date
+    endDate?: Date
+    riskLevel?: string
+    userIds?: string[]
+  }): Promise<RiskSummaryReportData> {
+    let query = this.riskAnalysisRepository.createQueryBuilder("risk").leftJoinAndSelect("risk.document", "document")
+
+    if (filters.startDate && filters.endDate) {
+      query = query.where("risk.createdAt BETWEEN :startDate AND :endDate", {
+        startDate: filters.startDate,
+        endDate: filters.endDate,
+      })
+    }
+
+    if (filters.riskLevel) {
+      query = query.andWhere("risk.riskLevel = :riskLevel", { riskLevel: filters.riskLevel })
+    }
+
+    if (filters.userIds && filters.userIds.length > 0) {
+      query = query.andWhere("document.uploadedBy IN (:...userIds)", { userIds: filters.userIds })
+    }
+
+    const riskAnalyses = await query.getMany()
+
+    const riskData = riskAnalyses.map((analysis) => ({
+      id: analysis.id,
+      documentId: analysis.documentId,
+      documentName: analysis.document.originalName,
+      riskLevel: analysis.riskLevel,
+      riskScore: Number(analysis.riskScore),
+      summary: analysis.summary,
+      detectedKeywords: analysis.detectedKeywords,
+      riskFactors: analysis.riskFactors,
+      analyzedBy: analysis.analyzedBy,
+      analyzedAt: analysis.createdAt,
+      uploadedBy: analysis.document.uploadedBy,
+    }))
+
+    // Calculate summary statistics
+    const byRiskLevel = {} as Record<RiskLevel, number>
+    const riskFactorCounts = {} as Record<string, number>
+    let totalRiskScore = 0
+
+    riskData.forEach((analysis) => {
+      byRiskLevel[analysis.riskLevel] = (byRiskLevel[analysis.riskLevel] || 0) + 1
+      totalRiskScore += analysis.riskScore
+
+      analysis.riskFactors.forEach((factor) => {
+        riskFactorCounts[factor.category] = (riskFactorCounts[factor.category] || 0) + 1
+      })
+    })
+
+    const topRiskFactors = Object.entries(riskFactorCounts)
+      .map(([category, count]) => ({ category, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10)
+
+    return {
+      riskAnalyses: riskData,
+      summary: {
+        totalAnalyses: riskData.length,
+        byRiskLevel,
+        averageRiskScore: riskData.length > 0 ? totalRiskScore / riskData.length : 0,
+        topRiskFactors,
+        criticalDocuments: byRiskLevel[RiskLevel.CRITICAL] || 0,
+      },
+    }
+  }
+
+  async aggregateAuditTrailData(filters: {
+    startDate?: Date
+    endDate?: Date
+    userIds?: string[]
+    actions?: string[]
+  }): Promise<AuditTrailReportData> {
+    let query = this.auditLogRepository.createQueryBuilder("audit")
+
+    if (filters.startDate && filters.endDate) {
+      query = query.where("audit.createdAt BETWEEN :startDate AND :endDate", {
+        startDate: filters.startDate,
+        endDate: filters.endDate,
+      })
+    }
+
+    if (filters.userIds && filters.userIds.length > 0) {
+      query = query.andWhere("audit.userId IN (:...userIds)", { userIds: filters.userIds })
+    }
+
+    if (filters.actions && filters.actions.length > 0) {
+      query = query.andWhere("audit.action IN (:...actions)", { actions: filters.actions })
+    }
+
+    query = query.orderBy("audit.createdAt", "DESC")
+
+    const auditLogs = await query.getMany()
+
+    const auditData = auditLogs.map((log) => ({
+      id: log.id,
+      userId: log.userId,
+      userEmail: log.userEmail,
+      action: log.action,
+      description: log.description,
+      resourceType: log.resourceType,
+      resourceId: log.resourceId,
+      success: log.success,
+      ipAddress: log.ipAddress,
+      createdAt: log.createdAt,
+    }))
+
+    // Calculate summary statistics
+    const byAction = {} as Record<string, number>
+    const byUser = {} as Record<string, number>
+    let failedOperations = 0
+
+    auditData.forEach((log) => {
+      byAction[log.action] = (byAction[log.action] || 0) + 1
+      byUser[log.userEmail] = (byUser[log.userEmail] || 0) + 1
+      if (!log.success) {
+        failedOperations++
+      }
+    })
+
+    return {
+      auditLogs: auditData,
+      summary: {
+        totalLogs: auditData.length,
+        byAction: byAction as any,
+        byUser,
+        failedOperations,
+        successRate: auditData.length > 0 ? ((auditData.length - failedOperations) / auditData.length) * 100 : 100,
+      },
+    }
+  }
+
+  async aggregateUserActivityData(filters: {
+    startDate?: Date
+    endDate?: Date
+    userIds?: string[]
+    department?: string
+  }): Promise<UserActivityReportData> {
+    let userQuery = this.userRepository.createQueryBuilder("user")
+
+    if (filters.userIds && filters.userIds.length > 0) {
+      userQuery = userQuery.where("user.id IN (:...userIds)", { userIds: filters.userIds })
+    }
+
+    if (filters.department) {
+      userQuery = userQuery.andWhere("user.department = :department", { department: filters.department })
+    }
+
+    const users = await userQuery.getMany()
+
+    // Get activity data for each user
+    const userData = await Promise.all(
+      users.map(async (user) => {
+        // Count documents uploaded
+        let docQuery = this.documentRepository.createQueryBuilder("doc").where("doc.uploadedBy = :userId", {
+          userId: user.id,
+        })
+
+        if (filters.startDate && filters.endDate) {
+          docQuery = docQuery.andWhere("doc.createdAt BETWEEN :startDate AND :endDate", {
+            startDate: filters.startDate,
+            endDate: filters.endDate,
+          })
+        }
+
+        const documentsUploaded = await docQuery.getCount()
+
+        // Count risk analyses performed
+        let riskQuery = this.riskAnalysisRepository.createQueryBuilder("risk").where("risk.analyzedBy = :userId", {
+          userId: user.id,
+        })
+
+        if (filters.startDate && filters.endDate) {
+          riskQuery = riskQuery.andWhere("risk.createdAt BETWEEN :startDate AND :endDate", {
+            startDate: filters.startDate,
+            endDate: filters.endDate,
+          })
+        }
+
+        const documentsAnalyzed = await riskQuery.getCount()
+
+        // Count high-risk documents
+        const riskDocuments = await this.riskAnalysisRepository
+          .createQueryBuilder("risk")
+          .leftJoin("risk.document", "doc")
+          .where("doc.uploadedBy = :userId", { userId: user.id })
+          .andWhere("risk.riskLevel IN (:...levels)", { levels: [RiskLevel.HIGH, RiskLevel.CRITICAL] })
+          .getCount()
+
+        // Count total audit actions
+        let auditQuery = this.auditLogRepository.createQueryBuilder("audit").where("audit.userId = :userId", {
+          userId: user.id,
+        })
+
+        if (filters.startDate && filters.endDate) {
+          auditQuery = auditQuery.andWhere("audit.createdAt BETWEEN :startDate AND :endDate", {
+            startDate: filters.startDate,
+            endDate: filters.endDate,
+          })
+        }
+
+        const totalActions = await auditQuery.getCount()
+
+        return {
+          id: user.id,
+          email: user.email,
+          fullName: user.fullName,
+          role: user.role,
+          department: user.department || "N/A",
+          documentsUploaded,
+          documentsAnalyzed,
+          lastActivity: user.lastLoginAt || user.updatedAt,
+          totalActions,
+          riskDocuments,
+        }
+      }),
+    )
+
+    // Calculate summary statistics
+    const byDepartment = {} as Record<string, number>
+    let activeUsers = 0
+    const thirtyDaysAgo = new Date()
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+    userData.forEach((user) => {
+      byDepartment[user.department] = (byDepartment[user.department] || 0) + 1
+      if (user.lastActivity >= thirtyDaysAgo) {
+        activeUsers++
+      }
+    })
+
+    return {
+      users: userData,
+      summary: {
+        totalUsers: userData.length,
+        activeUsers,
+        totalDocuments: userData.reduce((sum, user) => sum + user.documentsUploaded, 0),
+        totalAnalyses: userData.reduce((sum, user) => sum + user.documentsAnalyzed, 0),
+        byDepartment,
+      },
+    }
+  }
+
+  async aggregateSystemOverviewData(): Promise<SystemOverviewReportData> {
+    const [totalDocuments, totalUsers, totalRiskAnalyses, totalAuditLogs, totalNotifications] = await Promise.all([
+      this.documentRepository.count(),
+      this.userRepository.count(),
+      this.riskAnalysisRepository.count(),
+      this.auditLogRepository.count(),
+      this.notificationRepository.count(),
+    ])
+
+    // Get activity trends for last 30 days
+    const thirtyDaysAgo = new Date()
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+    const documentsPerDay = await this.getDocumentsPerDay(thirtyDaysAgo, new Date())
+    const userActivity = await this.getUserActivityPerDay(thirtyDaysAgo, new Date())
+    const riskTrends = await this.getRiskTrendsPerDay(thirtyDaysAgo, new Date())
+
+    return {
+      overview: {
+        totalDocuments,
+        totalUsers,
+        totalRiskAnalyses,
+        totalAuditLogs,
+        totalNotifications,
+        systemUptime: this.calculateUptime(),
+        lastBackup: new Date(), // Mock data - in real app, get from backup service
+      },
+      metrics: {
+        documentsPerDay,
+        riskTrends,
+        userActivity,
+        systemHealth: {
+          database: "healthy",
+          storage: "healthy",
+          notifications: "healthy",
+        },
+      },
+    }
+  }
+
+  async aggregateComplianceData(filters: {
+    startDate?: Date
+    endDate?: Date
+    documentIds?: string[]
+  }): Promise<ComplianceReportData> {
+    // Get all risk analyses for compliance assessment
+    let query = this.riskAnalysisRepository.createQueryBuilder("risk").leftJoinAndSelect("risk.document", "document")
+
+    if (filters.startDate && filters.endDate) {
+      query = query.where("risk.createdAt BETWEEN :startDate AND :endDate", {
+        startDate: filters.startDate,
+        endDate: filters.endDate,
+      })
+    }
+
+    if (filters.documentIds && filters.documentIds.length > 0) {
+      query = query.andWhere("risk.documentId IN (:...documentIds)", { documentIds: filters.documentIds })
+    }
+
+    const riskAnalyses = await query.getMany()
+
+    // Determine compliance status based on risk levels
+    const compliantDocuments = riskAnalyses.filter((r) => r.riskLevel === RiskLevel.LOW).length
+    const nonCompliantDocuments = riskAnalyses.filter(
+      (r) => r.riskLevel === RiskLevel.HIGH || r.riskLevel === RiskLevel.CRITICAL,
+    ).length
+    const pendingReview = riskAnalyses.filter((r) => r.riskLevel === RiskLevel.MEDIUM).length
+
+    // Generate violations for non-compliant documents
+    const violations = riskAnalyses
+      .filter((r) => r.riskLevel === RiskLevel.HIGH || r.riskLevel === RiskLevel.CRITICAL)
+      .map((analysis) => ({
+        documentId: analysis.documentId,
+        documentName: analysis.document.originalName,
+        violationType: this.determineViolationType(analysis.detectedKeywords),
+        severity: analysis.riskLevel,
+        description: analysis.summary,
+        detectedAt: analysis.createdAt,
+        status: "OPEN",
+      }))
+
+    // Generate recommendations
+    const recommendations = this.generateComplianceRecommendations(riskAnalyses)
+
+    return {
+      compliance: {
+        totalDocuments: riskAnalyses.length,
+        compliantDocuments,
+        nonCompliantDocuments,
+        pendingReview,
+        complianceRate: riskAnalyses.length > 0 ? (compliantDocuments / riskAnalyses.length) * 100 : 100,
+      },
+      violations,
+      recommendations,
+    }
+  }
+
+  private async getDocumentsPerDay(startDate: Date, endDate: Date): Promise<Array<{ date: string; count: number }>> {
+    const query = `
+      SELECT DATE(created_at) as date, COUNT(*) as count
+      FROM documents
+      WHERE created_at BETWEEN $1 AND $2
+      GROUP BY DATE(created_at)
+      ORDER BY date
+    `
+
+    // Mock implementation - in real app, use raw query
+    const result = []
+    const currentDate = new Date(startDate)
+    while (currentDate <= endDate) {
+      const count = Math.floor(Math.random() * 20) // Mock data
+      result.push({
+        date: currentDate.toISOString().split("T")[0],
+        count,
+      })
+      currentDate.setDate(currentDate.getDate() + 1)
+    }
+
+    return result
+  }
+
+  private async getUserActivityPerDay(
+    startDate: Date,
+    endDate: Date,
+  ): Promise<Array<{ date: string; activeUsers: number }>> {
+    // Mock implementation
+    const result = []
+    const currentDate = new Date(startDate)
+    while (currentDate <= endDate) {
+      const activeUsers = Math.floor(Math.random() * 50) + 10 // Mock data
+      result.push({
+        date: currentDate.toISOString().split("T")[0],
+        activeUsers,
+      })
+      currentDate.setDate(currentDate.getDate() + 1)
+    }
+
+    return result
+  }
+
+  private async getRiskTrendsPerDay(
+    startDate: Date,
+    endDate: Date,
+  ): Promise<Array<{ date: string; riskLevel: RiskLevel; count: number }>> {
+    // Mock implementation
+    const result = []
+    const currentDate = new Date(startDate)
+    const riskLevels = [RiskLevel.LOW, RiskLevel.MEDIUM, RiskLevel.HIGH, RiskLevel.CRITICAL]
+
+    while (currentDate <= endDate) {
+      riskLevels.forEach((level) => {
+        const count = Math.floor(Math.random() * 10) // Mock data
+        result.push({
+          date: currentDate.toISOString().split("T")[0],
+          riskLevel: level,
+          count,
+        })
+      })
+      currentDate.setDate(currentDate.getDate() + 1)
+    }
+
+    return result
+  }
+
+  private calculateUptime(): string {
+    // Mock uptime calculation
+    const uptimeHours = Math.floor(Math.random() * 8760) + 8000 // Mock: 8000+ hours
+    const days = Math.floor(uptimeHours / 24)
+    const hours = uptimeHours % 24
+    return `${days} days, ${hours} hours`
+  }
+
+  private determineViolationType(keywords: string[]): string {
+    if (keywords.some((k) => ["fraud", "illegal", "criminal"].includes(k.toLowerCase()))) {
+      return "Legal Violation"
+    }
+    if (keywords.some((k) => ["dispute", "litigation", "court"].includes(k.toLowerCase()))) {
+      return "Legal Dispute"
+    }
+    if (keywords.some((k) => ["incomplete", "missing", "expired"].includes(k.toLowerCase()))) {
+      return "Documentation Issue"
+    }
+    return "Compliance Issue"
+  }
+
+  private generateComplianceRecommendations(riskAnalyses: RiskAnalysis[]): Array<{
+    category: string
+    priority: string
+    description: string
+    actionRequired: string
+  }> {
+    const recommendations = []
+
+    const criticalCount = riskAnalyses.filter((r) => r.riskLevel === RiskLevel.CRITICAL).length
+    const highCount = riskAnalyses.filter((r) => r.riskLevel === RiskLevel.HIGH).length
+
+    if (criticalCount > 0) {
+      recommendations.push({
+        category: "Critical Risk Management",
+        priority: "URGENT",
+        description: `${criticalCount} documents have critical risk levels requiring immediate attention`,
+        actionRequired: "Review and remediate critical risk documents within 24 hours",
+      })
+    }
+
+    if (highCount > 0) {
+      recommendations.push({
+        category: "High Risk Management",
+        priority: "HIGH",
+        description: `${highCount} documents have high risk levels`,
+        actionRequired: "Schedule review and remediation within 72 hours",
+      })
+    }
+
+    // Add more recommendations based on patterns
+    const commonKeywords = this.getCommonRiskKeywords(riskAnalyses)
+    if (commonKeywords.length > 0) {
+      recommendations.push({
+        category: "Process Improvement",
+        priority: "MEDIUM",
+        description: `Common risk patterns detected: ${commonKeywords.join(", ")}`,
+        actionRequired: "Implement preventive measures and staff training",
+      })
+    }
+
+    return recommendations
+  }
+
+  private getCommonRiskKeywords(riskAnalyses: RiskAnalysis[]): string[] {
+    const keywordCounts = {} as Record<string, number>
+
+    riskAnalyses.forEach((analysis) => {
+      analysis.detectedKeywords.forEach((keyword) => {
+        keywordCounts[keyword] = (keywordCounts[keyword] || 0) + 1
+      })
+    })
+
+    return Object.entries(keywordCounts)
+      .filter(([, count]) => count >= 3) // Keywords appearing in 3+ documents
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 5)
+      .map(([keyword]) => keyword)
+  }
+}

--- a/backend/src/reporting/services/pdf-generator.service.ts
+++ b/backend/src/reporting/services/pdf-generator.service.ts
@@ -1,0 +1,453 @@
+import { Injectable, Logger } from "@nestjs/common"
+import * as fs from "fs"
+import type {
+  DocumentAnalysisReportData,
+  RiskSummaryReportData,
+  AuditTrailReportData,
+  UserActivityReportData,
+  SystemOverviewReportData,
+  ComplianceReportData,
+} from "../interfaces/report-data.interface"
+import * as PDFKit from "pdfkit" // Declare the PDFKit variable
+
+@Injectable()
+export class PdfGeneratorService {
+  private readonly logger = new Logger(PdfGeneratorService.name)
+
+  async generateDocumentAnalysisReport(
+    data: DocumentAnalysisReportData,
+    title: string,
+    filePath: string,
+  ): Promise<void> {
+    const doc = new PDFKit.PDFDocument({ margin: 50 })
+    const stream = fs.createWriteStream(filePath)
+    doc.pipe(stream)
+
+    // Header
+    this.addHeader(doc, title, "Document Analysis Report")
+
+    // Summary Section
+    doc.fontSize(16).text("Executive Summary", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    doc.text(`Total Documents: ${data.summary.totalDocuments}`)
+    doc.text(`Total Size: ${this.formatBytes(data.summary.totalSize)}`)
+    doc.text(`Average Risk Score: ${data.summary.averageRiskScore.toFixed(2)}`)
+    doc.moveDown()
+
+    // Risk Level Distribution
+    doc.fontSize(14).text("Risk Level Distribution", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    Object.entries(data.summary.byRiskLevel).forEach(([level, count]) => {
+      doc.text(`${level}: ${count} documents`)
+    })
+    doc.moveDown()
+
+    // MIME Type Distribution
+    doc.fontSize(14).text("Document Types", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    Object.entries(data.summary.byMimeType).forEach(([type, count]) => {
+      doc.text(`${type}: ${count} documents`)
+    })
+    doc.moveDown()
+
+    // Document Details
+    if (data.documents.length > 0) {
+      doc.addPage()
+      doc.fontSize(16).text("Document Details", { underline: true })
+      doc.moveDown()
+
+      data.documents.forEach((document, index) => {
+        if (index > 0 && index % 5 === 0) {
+          doc.addPage()
+        }
+
+        doc.fontSize(12)
+        doc.text(`Document: ${document.originalName}`, { continued: false })
+        doc.text(`Uploaded by: ${document.uploadedBy}`)
+        doc.text(`Upload Date: ${document.uploadedAt.toLocaleDateString()}`)
+        doc.text(`Size: ${this.formatBytes(document.size)}`)
+        doc.text(`Type: ${document.mimeType}`)
+
+        if (document.riskAnalysis) {
+          doc.text(`Risk Level: ${document.riskAnalysis.riskLevel}`)
+          doc.text(`Risk Score: ${document.riskAnalysis.riskScore}`)
+          doc.text(`Summary: ${document.riskAnalysis.summary}`)
+          if (document.riskAnalysis.detectedKeywords.length > 0) {
+            doc.text(`Keywords: ${document.riskAnalysis.detectedKeywords.join(", ")}`)
+          }
+        }
+        doc.moveDown()
+      })
+    }
+
+    this.addFooter(doc)
+    doc.end()
+
+    return new Promise((resolve, reject) => {
+      stream.on("finish", resolve)
+      stream.on("error", reject)
+    })
+  }
+
+  async generateRiskSummaryReport(data: RiskSummaryReportData, title: string, filePath: string): Promise<void> {
+    const doc = new PDFKit.PDFDocument({ margin: 50 })
+    const stream = fs.createWriteStream(filePath)
+    doc.pipe(stream)
+
+    // Header
+    this.addHeader(doc, title, "Risk Analysis Summary Report")
+
+    // Summary Section
+    doc.fontSize(16).text("Risk Overview", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    doc.text(`Total Risk Analyses: ${data.summary.totalAnalyses}`)
+    doc.text(`Average Risk Score: ${data.summary.averageRiskScore.toFixed(2)}`)
+    doc.text(`Critical Documents: ${data.summary.criticalDocuments}`)
+    doc.moveDown()
+
+    // Risk Level Distribution
+    doc.fontSize(14).text("Risk Level Distribution", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    Object.entries(data.summary.byRiskLevel).forEach(([level, count]) => {
+      const percentage = ((count / data.summary.totalAnalyses) * 100).toFixed(1)
+      doc.text(`${level}: ${count} documents (${percentage}%)`)
+    })
+    doc.moveDown()
+
+    // Top Risk Factors
+    doc.fontSize(14).text("Top Risk Factors", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    data.summary.topRiskFactors.forEach((factor) => {
+      doc.text(`${factor.category}: ${factor.count} occurrences`)
+    })
+    doc.moveDown()
+
+    // High Risk Documents
+    const highRiskDocs = data.riskAnalyses.filter((r) => r.riskLevel === "HIGH" || r.riskLevel === "CRITICAL")
+    if (highRiskDocs.length > 0) {
+      doc.addPage()
+      doc.fontSize(16).text("High Risk Documents", { underline: true })
+      doc.moveDown()
+
+      highRiskDocs.forEach((analysis, index) => {
+        if (index > 0 && index % 3 === 0) {
+          doc.addPage()
+        }
+
+        doc.fontSize(12)
+        doc.text(`Document: ${analysis.documentName}`, { continued: false })
+        doc.text(`Risk Level: ${analysis.riskLevel}`)
+        doc.text(`Risk Score: ${analysis.riskScore}`)
+        doc.text(`Uploaded by: ${analysis.uploadedBy}`)
+        doc.text(`Analyzed by: ${analysis.analyzedBy}`)
+        doc.text(`Analysis Date: ${analysis.analyzedAt.toLocaleDateString()}`)
+        doc.text(`Summary: ${analysis.summary}`)
+
+        if (analysis.detectedKeywords.length > 0) {
+          doc.text(`Keywords: ${analysis.detectedKeywords.join(", ")}`)
+        }
+
+        if (analysis.riskFactors.length > 0) {
+          doc.text("Risk Factors:")
+          analysis.riskFactors.forEach((factor) => {
+            doc.text(`  • ${factor.category} (${factor.severity}): ${factor.description}`)
+          })
+        }
+        doc.moveDown()
+      })
+    }
+
+    this.addFooter(doc)
+    doc.end()
+
+    return new Promise((resolve, reject) => {
+      stream.on("finish", resolve)
+      stream.on("error", reject)
+    })
+  }
+
+  async generateAuditTrailReport(data: AuditTrailReportData, title: string, filePath: string): Promise<void> {
+    const doc = new PDFKit.PDFDocument({ margin: 50 })
+    const stream = fs.createWriteStream(filePath)
+    doc.pipe(stream)
+
+    // Header
+    this.addHeader(doc, title, "Audit Trail Report")
+
+    // Summary Section
+    doc.fontSize(16).text("Audit Summary", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    doc.text(`Total Audit Logs: ${data.summary.totalLogs}`)
+    doc.text(`Failed Operations: ${data.summary.failedOperations}`)
+    doc.text(`Success Rate: ${data.summary.successRate.toFixed(2)}%`)
+    doc.moveDown()
+
+    // Action Distribution
+    doc.fontSize(14).text("Actions Distribution", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    Object.entries(data.summary.byAction).forEach(([action, count]) => {
+      doc.text(`${action}: ${count} occurrences`)
+    })
+    doc.moveDown()
+
+    // Top Users
+    doc.fontSize(14).text("Most Active Users", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    const topUsers = Object.entries(data.summary.byUser)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 10)
+    topUsers.forEach(([user, count]) => {
+      doc.text(`${user}: ${count} actions`)
+    })
+    doc.moveDown()
+
+    // Recent Activities
+    if (data.auditLogs.length > 0) {
+      doc.addPage()
+      doc.fontSize(16).text("Recent Activities", { underline: true })
+      doc.moveDown()
+
+      data.auditLogs.slice(0, 50).forEach((log, index) => {
+        if (index > 0 && index % 10 === 0) {
+          doc.addPage()
+        }
+
+        doc.fontSize(10)
+        doc.text(`${log.createdAt.toLocaleString()} - ${log.userEmail}`)
+        doc.text(`Action: ${log.action}`)
+        doc.text(`Description: ${log.description}`)
+        doc.text(`Resource: ${log.resourceType}/${log.resourceId}`)
+        doc.text(`Status: ${log.success ? "Success" : "Failed"}`)
+        doc.text(`IP: ${log.ipAddress}`)
+        doc.moveDown(0.5)
+      })
+    }
+
+    this.addFooter(doc)
+    doc.end()
+
+    return new Promise((resolve, reject) => {
+      stream.on("finish", resolve)
+      stream.on("error", reject)
+    })
+  }
+
+  async generateUserActivityReport(data: UserActivityReportData, title: string, filePath: string): Promise<void> {
+    const doc = new PDFKit.PDFDocument({ margin: 50 })
+    const stream = fs.createWriteStream(filePath)
+    doc.pipe(stream)
+
+    // Header
+    this.addHeader(doc, title, "User Activity Report")
+
+    // Summary Section
+    doc.fontSize(16).text("Activity Overview", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    doc.text(`Total Users: ${data.summary.totalUsers}`)
+    doc.text(`Active Users: ${data.summary.activeUsers}`)
+    doc.text(`Total Documents: ${data.summary.totalDocuments}`)
+    doc.text(`Total Analyses: ${data.summary.totalAnalyses}`)
+    doc.moveDown()
+
+    // Department Distribution
+    doc.fontSize(14).text("Users by Department", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    Object.entries(data.summary.byDepartment).forEach(([dept, count]) => {
+      doc.text(`${dept}: ${count} users`)
+    })
+    doc.moveDown()
+
+    // User Details
+    if (data.users.length > 0) {
+      doc.addPage()
+      doc.fontSize(16).text("User Activity Details", { underline: true })
+      doc.moveDown()
+
+      data.users.forEach((user, index) => {
+        if (index > 0 && index % 8 === 0) {
+          doc.addPage()
+        }
+
+        doc.fontSize(12)
+        doc.text(`User: ${user.fullName} (${user.email})`)
+        doc.text(`Role: ${user.role}`)
+        doc.text(`Department: ${user.department}`)
+        doc.text(`Documents Uploaded: ${user.documentsUploaded}`)
+        doc.text(`Documents Analyzed: ${user.documentsAnalyzed}`)
+        doc.text(`Risk Documents: ${user.riskDocuments}`)
+        doc.text(`Total Actions: ${user.totalActions}`)
+        doc.text(`Last Activity: ${user.lastActivity.toLocaleDateString()}`)
+        doc.moveDown()
+      })
+    }
+
+    this.addFooter(doc)
+    doc.end()
+
+    return new Promise((resolve, reject) => {
+      stream.on("finish", resolve)
+      stream.on("error", reject)
+    })
+  }
+
+  async generateSystemOverviewReport(data: SystemOverviewReportData, title: string, filePath: string): Promise<void> {
+    const doc = new PDFKit.PDFDocument({ margin: 50 })
+    const stream = fs.createWriteStream(filePath)
+    doc.pipe(stream)
+
+    // Header
+    this.addHeader(doc, title, "System Overview Report")
+
+    // System Overview
+    doc.fontSize(16).text("System Statistics", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    doc.text(`Total Documents: ${data.overview.totalDocuments}`)
+    doc.text(`Total Users: ${data.overview.totalUsers}`)
+    doc.text(`Total Risk Analyses: ${data.overview.totalRiskAnalyses}`)
+    doc.text(`Total Audit Logs: ${data.overview.totalAuditLogs}`)
+    doc.text(`Total Notifications: ${data.overview.totalNotifications}`)
+    doc.text(`System Uptime: ${data.overview.systemUptime}`)
+    doc.text(`Last Backup: ${data.overview.lastBackup.toLocaleDateString()}`)
+    doc.moveDown()
+
+    // System Health
+    doc.fontSize(14).text("System Health", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    doc.text(`Database: ${data.metrics.systemHealth.database}`)
+    doc.text(`Storage: ${data.metrics.systemHealth.storage}`)
+    doc.text(`Notifications: ${data.metrics.systemHealth.notifications}`)
+    doc.moveDown()
+
+    // Activity Trends
+    doc.fontSize(14).text("Activity Trends (Last 30 Days)", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+
+    if (data.metrics.documentsPerDay.length > 0) {
+      doc.text("Documents per Day:")
+      data.metrics.documentsPerDay.slice(-7).forEach((day) => {
+        doc.text(`  ${day.date}: ${day.count} documents`)
+      })
+      doc.moveDown()
+    }
+
+    if (data.metrics.userActivity.length > 0) {
+      doc.text("User Activity:")
+      data.metrics.userActivity.slice(-7).forEach((day) => {
+        doc.text(`  ${day.date}: ${day.activeUsers} active users`)
+      })
+      doc.moveDown()
+    }
+
+    this.addFooter(doc)
+    doc.end()
+
+    return new Promise((resolve, reject) => {
+      stream.on("finish", resolve)
+      stream.on("error", reject)
+    })
+  }
+
+  async generateComplianceReport(data: ComplianceReportData, title: string, filePath: string): Promise<void> {
+    const doc = new PDFKit.PDFDocument({ margin: 50 })
+    const stream = fs.createWriteStream(filePath)
+    doc.pipe(stream)
+
+    // Header
+    this.addHeader(doc, title, "Compliance Report")
+
+    // Compliance Overview
+    doc.fontSize(16).text("Compliance Overview", { underline: true })
+    doc.moveDown()
+    doc.fontSize(12)
+    doc.text(`Total Documents: ${data.compliance.totalDocuments}`)
+    doc.text(`Compliant Documents: ${data.compliance.compliantDocuments}`)
+    doc.text(`Non-Compliant Documents: ${data.compliance.nonCompliantDocuments}`)
+    doc.text(`Pending Review: ${data.compliance.pendingReview}`)
+    doc.text(`Compliance Rate: ${data.compliance.complianceRate.toFixed(2)}%`)
+    doc.moveDown()
+
+    // Violations
+    if (data.violations.length > 0) {
+      doc.fontSize(14).text("Compliance Violations", { underline: true })
+      doc.moveDown()
+
+      data.violations.forEach((violation, index) => {
+        if (index > 0 && index % 5 === 0) {
+          doc.addPage()
+        }
+
+        doc.fontSize(12)
+        doc.text(`Document: ${violation.documentName}`)
+        doc.text(`Violation Type: ${violation.violationType}`)
+        doc.text(`Severity: ${violation.severity}`)
+        doc.text(`Description: ${violation.description}`)
+        doc.text(`Detected: ${violation.detectedAt.toLocaleDateString()}`)
+        doc.text(`Status: ${violation.status}`)
+        doc.moveDown()
+      })
+    }
+
+    // Recommendations
+    if (data.recommendations.length > 0) {
+      doc.addPage()
+      doc.fontSize(14).text("Recommendations", { underline: true })
+      doc.moveDown()
+
+      data.recommendations.forEach((rec) => {
+        doc.fontSize(12)
+        doc.text(`Category: ${rec.category}`)
+        doc.text(`Priority: ${rec.priority}`)
+        doc.text(`Description: ${rec.description}`)
+        doc.text(`Action Required: ${rec.actionRequired}`)
+        doc.moveDown()
+      })
+    }
+
+    this.addFooter(doc)
+    doc.end()
+
+    return new Promise((resolve, reject) => {
+      stream.on("finish", resolve)
+      stream.on("error", reject)
+    })
+  }
+
+  private addHeader(doc: PDFKit.PDFDocument, title: string, subtitle: string): void {
+    doc.fontSize(20).text(title, { align: "center" })
+    doc.fontSize(14).text(subtitle, { align: "center" })
+    doc.text(`Generated on: ${new Date().toLocaleDateString()}`, { align: "center" })
+    doc.moveDown(2)
+  }
+
+  private addFooter(doc: PDFKit.PDFDocument): void {
+    const pages = doc.bufferedPageRange()
+    for (let i = 0; i < pages.count; i++) {
+      doc.switchToPage(i)
+      doc.fontSize(10).text(`Page ${i + 1} of ${pages.count}`, 50, doc.page.height - 50, {
+        align: "center",
+      })
+    }
+  }
+
+  private formatBytes(bytes: number): string {
+    if (bytes === 0) return "0 Bytes"
+    const k = 1024
+    const sizes = ["Bytes", "KB", "MB", "GB"]
+    const i = Math.floor(Math.log(bytes) / Math.log(k))
+    return `${Number.parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`
+  }
+}


### PR DESCRIPTION
This pull request implements the **Reporting module** for the Smalda backend project. The module is designed to generate, manage, and expose reports related to land ownership document analysis and flagged risk metrics.

### ✨ Features Added:

* `ReportingModule` created with NestJS module structure
* Service layer (`reporting.service.ts`) for handling core logic
* Controller (`reporting.controller.ts`) with endpoints to fetch reports
* DTOs for report generation input/output
* Placeholder logic for generating basic summaries from risk analysis (to be improved)
* Integration with existing user authentication for scoped access

### ✅ Todos in Future PRs:

* Add unit and e2e tests
* Connect with risk engine data
* Export reports as PDF/CSV
* Add admin-level filters and pagination

### 📁 Directory:

```
src/
 └── reporting/
      ├── reporting.module.ts
      ├── reporting.service.ts
      ├── reporting.controller.ts
      └── dto/
```

closes #64 