### PR TITLE
feat(document-history): implement document history module`

### DIFF
--- a/backend/src/document-history/document-history.controller.ts
+++ b/backend/src/document-history/document-history.controller.ts
@@ -1,0 +1,170 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Delete,
+  Query,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+} from "@nestjs/common"
+import type { DocumentHistoryService } from "./document-history.service"
+import type { CreateDocumentDto } from "./dto/create-document.dto"
+import type { UpdateDocumentDto } from "./dto/update-document.dto"
+import type { FilterDocumentVersionsDto } from "./dto/filter-document-versions.dto"
+import type { FilterDocumentsDto } from "./dto/filter-documents.dto"
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from "@nestjs/swagger"
+import { Document } from "./entities/document.entity"
+import { DocumentVersion } from "./entities/document-version.entity"
+import { DocumentType } from "./enums/document-type.enum"
+
+@ApiTags("Document History")
+@Controller("documents")
+export class DocumentHistoryController {
+  constructor(private readonly documentHistoryService: DocumentHistoryService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: "Create a new document and its initial version (OCR performed automatically if text not provided)",
+  })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: "Document and its first version successfully created.",
+    type: Document,
+  })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: "Invalid input data." })
+  async create(createDocumentDto: CreateDocumentDto) {
+    return this.documentHistoryService.createDocument(createDocumentDto)
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Retrieve all current documents with optional filtering and pagination' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'List of current documents.', type: [Document] })
+  @ApiQuery({ name: 'name', required: false, type: String, description: 'Filter by document name (partial match)' })
+  @ApiQuery({ name: 'documentType', required: false, enum: DocumentType, description: 'Filter by document type' })
+  @ApiQuery({ name: 'ownerId', required: false, type: String, description: 'Filter by document owner ID' })
+  @ApiQuery({ name: 'propertyOwnerId', required: false, type: String, description: 'Filter by property owner ID' }) // NEW
+  @ApiQuery({ name: 'tag', required: false, type: String, description: 'Filter by a specific tag name associated with the document' })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number for pagination' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Number of items per page' })
+  @ApiQuery({ name: 'sortBy', required: false, type: String, description: 'Field to sort by (e.g., createdAt, name)' })
+  @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'], description: 'Sort order (ASC or DESC)' })
+  async findAllCurrent(@Query() filterDto: FilterDocumentsDto) {
+    return this.documentHistoryService.findAllDocuments(filterDto);
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Retrieve a single document by ID with its current version, tags, and property owner' }) // Updated summary
+  @ApiResponse({ status: HttpStatus.OK, description: 'Document found with its current version.', type: Document })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Document not found.' })
+  @ApiParam({ name: 'id', type: String, description: 'UUID of the document' })
+  async findOne(@Param('id') id: string) {
+    const document = await this.documentHistoryService.findOneDocument(id);
+    if (!document) {
+      throw new NotFoundException(`Document with ID "${id}" not found.`);
+    }
+    return document;
+  }
+
+  @Patch(":id")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Update a document and create a new version (OCR performed automatically if text not provided)",
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Document successfully updated and new version created.",
+    type: Document,
+  })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Document not found." })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: "Invalid input data." })
+  @ApiParam({ name: "id", type: String, description: "UUID of the document to update" })
+  async update(@Param('id') id: string, updateDocumentDto: UpdateDocumentDto) {
+    const updatedDocument = await this.documentHistoryService.updateDocument(id, updateDocumentDto)
+    if (!updatedDocument) {
+      throw new NotFoundException(`Document with ID "${id}" not found.`)
+    }
+    return updatedDocument
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Soft delete a document and its versions' })
+  @ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'Document and its versions successfully soft-deleted.' })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Document not found.' })
+  @ApiParam({ name: 'id', type: String, description: 'UUID of the document to delete' })
+  async remove(@Param('id') id: string) {
+    const result = await this.documentHistoryService.removeDocument(id);
+    if (!result) {
+      throw new NotFoundException(`Document with ID "${id}" not found.`);
+    }
+  }
+
+  // --- Document Version History Endpoints ---
+
+  @Get(":documentId/versions")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Retrieve all versions for a specific document" })
+  @ApiResponse({ status: HttpStatus.OK, description: "List of document versions.", type: [DocumentVersion] })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Document not found." })
+  @ApiParam({ name: "documentId", type: String, description: "UUID of the document" })
+  @ApiQuery({ name: "versionNumber", required: false, type: Number, description: "Filter by specific version number" })
+  @ApiQuery({
+    name: "uploadedBy",
+    required: false,
+    type: String,
+    description: "Filter by user who uploaded the version",
+  })
+  @ApiQuery({
+    name: "riskStatus",
+    required: false,
+    enum: ["low_risk", "medium_risk", "high_risk", "under_review", "resolved", "no_risk"],
+    description: "Filter by risk status of the version",
+  })
+  @ApiQuery({
+    name: "startDate",
+    required: false,
+    type: String,
+    description: "Filter by version creation date (start)",
+  })
+  @ApiQuery({ name: "endDate", required: false, type: String, description: "Filter by version creation date (end)" })
+  @ApiQuery({ name: "page", required: false, type: Number, description: "Page number for pagination" })
+  @ApiQuery({ name: "limit", required: false, type: Number, description: "Number of items per page" })
+  @ApiQuery({
+    name: "sortBy",
+    required: false,
+    type: String,
+    description: "Field to sort by (e.g., createdAt, versionNumber)",
+  })
+  @ApiQuery({ name: "sortOrder", required: false, enum: ["ASC", "DESC"], description: "Sort order (ASC or DESC)" })
+  async getDocumentVersions(@Param('documentId') documentId: string, @Query() filterDto: FilterDocumentVersionsDto) {
+    const documentExists = await this.documentHistoryService.checkDocumentExists(documentId)
+    if (!documentExists) {
+      throw new NotFoundException(`Document with ID "${documentId}" not found.`)
+    }
+    return this.documentHistoryService.findDocumentVersions(documentId, filterDto)
+  }
+
+  @Get(":documentId/versions/:versionNumber")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Retrieve a specific version of a document" })
+  @ApiResponse({ status: HttpStatus.OK, description: "Specific document version found.", type: DocumentVersion })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Document or version not found." })
+  @ApiParam({ name: "documentId", type: String, description: "UUID of the document" })
+  @ApiParam({ name: "versionNumber", type: Number, description: "Specific version number to retrieve" })
+  async getSpecificDocumentVersion(
+    @Param('documentId') documentId: string,
+    @Param('versionNumber') versionNumber: number,
+  ) {
+    const version = await this.documentHistoryService.findSpecificDocumentVersion(documentId, versionNumber)
+    if (!version) {
+      throw new NotFoundException(`Version ${versionNumber} for document "${documentId}" not found.`)
+    }
+    return version
+  }
+}

--- a/backend/src/document-history/document-history.module.ts
+++ b/backend/src/document-history/document-history.module.ts
@@ -1,0 +1,22 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { DocumentHistoryService } from "./document-history.service"
+import { DocumentHistoryController } from "./document-history.controller"
+import { Document } from "./entities/document.entity"
+import { DocumentVersion } from "./entities/document-version.entity"
+import { OcrExtractionModule } from "../ocr-extraction/ocr-extraction.module"
+import { TaggingModule } from "../tagging/tagging.module"
+import { PropertyOwnerModule } from "../property-owner/property-owner.module" // NEW
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Document, DocumentVersion]),
+    OcrExtractionModule,
+    TaggingModule,
+    PropertyOwnerModule, // NEW
+  ],
+  controllers: [DocumentHistoryController],
+  providers: [DocumentHistoryService],
+  exports: [DocumentHistoryService],
+})
+export class DocumentHistoryModule {}

--- a/backend/src/document-history/document-history.service.ts
+++ b/backend/src/document-history/document-history.service.ts
@@ -1,0 +1,322 @@
+import { Injectable, BadRequestException } from "@nestjs/common"
+import { type Repository, IsNull } from "typeorm"
+import { Document } from "./entities/document.entity"
+import { DocumentVersion } from "./entities/document-version.entity"
+import type { CreateDocumentDto } from "./dto/create-document.dto"
+import type { UpdateDocumentDto } from "./dto/update-document.dto"
+import type { FilterDocumentVersionsDto } from "./dto/filter-document-versions.dto"
+import type { FilterDocumentsDto } from "./dto/filter-documents.dto"
+import type { OcrExtractionService } from "../ocr-extraction/ocr-extraction.service"
+import type { TaggingService } from "../tagging/tagging.service"
+import type { PropertyOwnerService } from "../property-owner/property-owner.service" // NEW
+
+@Injectable()
+export class DocumentHistoryService {
+  constructor(
+    private documentRepository: Repository<Document>,
+    private documentVersionRepository: Repository<DocumentVersion>,
+    private ocrExtractionService: OcrExtractionService,
+    private taggingService: TaggingService,
+    private propertyOwnerService: PropertyOwnerService, // NEW
+  ) {}
+
+  /**
+   * Creates a new document and its initial version.
+   * Performs OCR if extractedText is not provided in the DTO.
+   * Associates tags and property owner with the document.
+   * @param createDocumentDto DTO containing document and initial version data.
+   * @returns The created Document entity with its current version.
+   */
+  async createDocument(createDocumentDto: CreateDocumentDto): Promise<Document> {
+    const {
+      name,
+      description,
+      documentType,
+      ownerId,
+      propertyOwnerId, // NEW
+      tagNames,
+      uploadedBy,
+      documentUrl,
+      riskReport,
+      riskSummary,
+      riskStatus,
+      uploadNotes,
+      extractedText,
+    } = createDocumentDto
+
+    // Validate property owner exists if provided
+    if (propertyOwnerId) {
+      const propertyOwner = await this.propertyOwnerService.findOne(propertyOwnerId)
+      if (!propertyOwner) {
+        throw new BadRequestException(`Property owner with ID "${propertyOwnerId}" not found.`)
+      }
+    }
+
+    // Perform OCR if extractedText is not provided
+    const finalExtractedText = extractedText || (await this.ocrExtractionService.extractText(documentUrl))
+
+    // Find or create tags based on provided tag names
+    const tags = tagNames ? await this.taggingService.findOrCreateTags(tagNames) : []
+
+    // Create the main document entry
+    const document = this.documentRepository.create({
+      name,
+      description,
+      documentType,
+      ownerId,
+      propertyOwnerId, // NEW
+      tags,
+    })
+
+    // Create the first version
+    const initialVersion = this.documentVersionRepository.create({
+      document: document,
+      versionNumber: 1,
+      uploadedBy,
+      documentUrl,
+      riskReport,
+      riskSummary,
+      riskStatus,
+      uploadNotes,
+      extractedText: finalExtractedText,
+    })
+
+    // Use a transaction to ensure atomicity
+    return this.documentRepository.manager.transaction(async (transactionalEntityManager) => {
+      const savedDocument = await transactionalEntityManager.save(document)
+      initialVersion.document = savedDocument
+      const savedVersion = await transactionalEntityManager.save(initialVersion)
+
+      // Update the document to point to its current version
+      savedDocument.currentVersion = savedVersion
+      savedDocument.currentVersionId = savedVersion.id
+      return transactionalEntityManager.save(savedDocument)
+    })
+  }
+
+  /**
+   * Retrieves all current documents with optional filtering and pagination.
+   * Eagerly loads the current version, tags, and property owner for each document.
+   * @param filterDto Filter and pagination options.
+   * @returns An object containing current documents and total count.
+   */
+  async findAllDocuments(filterDto: FilterDocumentsDto): Promise<{ data: Document[]; total: number }> {
+    const {
+      name,
+      documentType,
+      ownerId,
+      propertyOwnerId, // NEW
+      tag,
+      page = 1,
+      limit = 10,
+      sortBy = "createdAt",
+      sortOrder = "DESC",
+    } = filterDto
+
+    const queryBuilder = this.documentRepository.createQueryBuilder("document")
+
+    queryBuilder.leftJoinAndSelect("document.currentVersion", "currentVersion")
+    queryBuilder.leftJoinAndSelect("document.tags", "tags")
+    queryBuilder.leftJoinAndSelect("document.owner", "owner") // NEW: Eager load property owner
+    queryBuilder.where("document.deletedAt IS NULL")
+
+    if (name) {
+      queryBuilder.andWhere("document.name ILIKE :name", { name: `%${name}%` })
+    }
+    if (documentType) {
+      queryBuilder.andWhere("document.documentType = :documentType", { documentType })
+    }
+    if (ownerId) {
+      queryBuilder.andWhere("document.ownerId = :ownerId", { ownerId })
+    }
+    if (propertyOwnerId) {
+      // NEW: Filter by property owner
+      queryBuilder.andWhere("document.propertyOwnerId = :propertyOwnerId", { propertyOwnerId })
+    }
+    if (tag) {
+      queryBuilder.andWhere("tags.name ILIKE :tag", { tag: `%${tag}%` })
+    }
+
+    queryBuilder.orderBy(`document.${sortBy}`, sortOrder)
+    queryBuilder.skip((page - 1) * limit).take(limit)
+
+    const [data, total] = await queryBuilder.getManyAndCount()
+    return { data, total }
+  }
+
+  /**
+   * Retrieves a single document by ID, including its current version, tags, and property owner.
+   * @param id The UUID of the document.
+   * @returns The Document entity or undefined if not found.
+   */
+  async findOneDocument(id: string): Promise<Document | undefined> {
+    return this.documentRepository.findOne({
+      where: { id, deletedAt: IsNull() },
+      relations: ["currentVersion", "tags", "owner"], // NEW: Include property owner
+    })
+  }
+
+  /**
+   * Updates a document's metadata and creates a new version for document-specific data.
+   * Performs OCR if extractedText is not provided in the DTO.
+   * Updates associated tags and property owner.
+   * @param id The UUID of the document to update.
+   * @param updateDocumentDto DTO containing updated document and new version data.
+   * @returns The updated Document entity with its new current version.
+   */
+  async updateDocument(id: string, updateDocumentDto: UpdateDocumentDto): Promise<Document | undefined> {
+    const document = await this.findOneDocument(id)
+    if (!document) {
+      return undefined
+    }
+
+    // Validate property owner exists if provided
+    if (updateDocumentDto.propertyOwnerId !== undefined) {
+      if (updateDocumentDto.propertyOwnerId) {
+        const propertyOwner = await this.propertyOwnerService.findOne(updateDocumentDto.propertyOwnerId)
+        if (!propertyOwner) {
+          throw new BadRequestException(`Property owner with ID "${updateDocumentDto.propertyOwnerId}" not found.`)
+        }
+      }
+    }
+
+    // Update document metadata fields
+    document.name = updateDocumentDto.name ?? document.name
+    document.description = updateDocumentDto.description ?? document.description
+    document.documentType = updateDocumentDto.documentType ?? document.documentType
+    document.ownerId = updateDocumentDto.ownerId ?? document.ownerId
+    document.propertyOwnerId = updateDocumentDto.propertyOwnerId ?? document.propertyOwnerId // NEW
+
+    // Update tags if provided
+    if (updateDocumentDto.tagNames !== undefined) {
+      document.tags = await this.taggingService.findOrCreateTags(updateDocumentDto.tagNames)
+    }
+
+    // Perform OCR if extractedText is not provided in the update DTO
+    const finalExtractedText =
+      updateDocumentDto.extractedText || (await this.ocrExtractionService.extractText(updateDocumentDto.documentUrl))
+
+    // Create a new version
+    const newVersion = this.documentVersionRepository.create({
+      document: document,
+      versionNumber: (document.currentVersion?.versionNumber || 0) + 1,
+      uploadedBy: updateDocumentDto.uploadedBy,
+      documentUrl: updateDocumentDto.documentUrl,
+      riskReport: updateDocumentDto.riskReport,
+      riskSummary: updateDocumentDto.riskSummary,
+      riskStatus: updateDocumentDto.riskStatus,
+      uploadNotes: updateDocumentDto.uploadNotes,
+      extractedText: finalExtractedText,
+    })
+
+    // Ensure required fields for new version are present
+    if (!newVersion.uploadedBy || !newVersion.documentUrl || !newVersion.riskReport || !newVersion.riskStatus) {
+      throw new BadRequestException(
+        "Missing required fields for new document version: uploadedBy, documentUrl, riskReport, riskStatus.",
+      )
+    }
+
+    return this.documentRepository.manager.transaction(async (transactionalEntityManager) => {
+      const savedNewVersion = await transactionalEntityManager.save(newVersion)
+
+      // Update the document to point to the new current version
+      document.currentVersion = savedNewVersion
+      document.currentVersionId = savedNewVersion.id
+      return transactionalEntityManager.save(document)
+    })
+  }
+
+  /**
+   * Soft deletes a document and all its associated versions.
+   * @param id The UUID of the document to delete.
+   * @returns True if deleted, false if not found.
+   */
+  async removeDocument(id: string): Promise<boolean> {
+    const document = await this.documentRepository.findOne({ where: { id, deletedAt: IsNull() } })
+    if (!document) {
+      return false
+    }
+
+    return this.documentRepository.manager.transaction(async (transactionalEntityManager) => {
+      // Soft delete all versions associated with this document
+      await transactionalEntityManager.softDelete(DocumentVersion, { document: { id: document.id } })
+      // Soft delete the document itself
+      const result = await transactionalEntityManager.softDelete(Document, id)
+      return result.affected > 0
+    })
+  }
+
+  /**
+   * Retrieves all versions for a specific document with optional filtering and pagination.
+   * @param documentId The UUID of the document.
+   * @param filterDto Filter and pagination options.
+   * @returns An object containing document versions and total count.
+   */
+  async findDocumentVersions(
+    documentId: string,
+    filterDto: FilterDocumentVersionsDto,
+  ): Promise<{ data: DocumentVersion[]; total: number }> {
+    const {
+      versionNumber,
+      uploadedBy,
+      riskStatus,
+      startDate,
+      endDate,
+      page = 1,
+      limit = 10,
+      sortBy = "createdAt",
+      sortOrder = "DESC",
+    } = filterDto
+
+    const queryBuilder = this.documentVersionRepository.createQueryBuilder("version")
+
+    queryBuilder.where("version.documentId = :documentId", { documentId })
+
+    if (versionNumber) {
+      queryBuilder.andWhere("version.versionNumber = :versionNumber", { versionNumber })
+    }
+    if (uploadedBy) {
+      queryBuilder.andWhere("version.uploadedBy = :uploadedBy", { uploadedBy })
+    }
+    if (riskStatus) {
+      queryBuilder.andWhere("version.riskStatus = :riskStatus", { riskStatus })
+    }
+    if (startDate) {
+      queryBuilder.andWhere("version.createdAt >= :startDate", { startDate: new Date(startDate) })
+    }
+    if (endDate) {
+      queryBuilder.andWhere("version.createdAt <= :endDate", { endDate: new Date(endDate) })
+    }
+
+    queryBuilder.orderBy(`version.${sortBy}`, sortOrder)
+    queryBuilder.skip((page - 1) * limit).take(limit)
+
+    const [data, total] = await queryBuilder.getManyAndCount()
+    return { data, total }
+  }
+
+  /**
+   * Retrieves a specific version of a document by its document ID and version number.
+   * @param documentId The UUID of the document.
+   * @param versionNumber The specific version number.
+   * @returns The DocumentVersion entity or undefined if not found.
+   */
+  async findSpecificDocumentVersion(documentId: string, versionNumber: number): Promise<DocumentVersion | undefined> {
+    return this.documentVersionRepository.findOne({
+      where: {
+        document: { id: documentId },
+        versionNumber: versionNumber,
+      },
+    })
+  }
+
+  /**
+   * Helper to check if a document exists and is not soft-deleted.
+   * @param id The UUID of the document.
+   * @returns True if document exists, false otherwise.
+   */
+  async checkDocumentExists(id: string): Promise<boolean> {
+    const count = await this.documentRepository.count({ where: { id, deletedAt: IsNull() } })
+    return count > 0
+  }
+}

--- a/backend/src/document-history/document-history.spec.ts
+++ b/backend/src/document-history/document-history.spec.ts
@@ -1,0 +1,759 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { DocumentHistoryController } from "./document-history.controller"
+import { DocumentHistoryService } from "./document-history.service"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { Document } from "./entities/document.entity"
+import { DocumentVersion } from "./entities/document-version.entity"
+import type { Repository } from "typeorm"
+import type { CreateDocumentDto } from "./dto/create-document.dto"
+import type { UpdateDocumentDto } from "./dto/update-document.dto"
+import type { FilterDocumentVersionsDto } from "./dto/filter-document-versions.dto"
+import type { FilterDocumentsDto } from "./dto/filter-documents.dto" // NEW
+import { DocumentType } from "./enums/document-type.enum"
+import { RiskStatus } from "./enums/risk-status.enum"
+import { NotFoundException, BadRequestException } from "@nestjs/common"
+import { OcrExtractionService } from "../ocr-extraction/ocr-extraction.service"
+import { TaggingService } from "../tagging/tagging.service" // NEW: Import TaggingService
+import type { Tag } from "../tagging/entities/tag.entity" // NEW: Import Tag entity
+import { jest } from "@jest/globals"
+
+// Mock Repositories
+const mockDocumentRepository = {
+  create: jest.fn(),
+  save: jest.fn(),
+  findOne: jest.fn(),
+  count: jest.fn(),
+  softDelete: jest.fn(),
+  manager: {
+    transaction: jest.fn((cb) =>
+      cb({
+        save: jest.fn((entity) => Promise.resolve({ ...entity, id: entity.id || "new-uuid" })),
+        softDelete: jest.fn(),
+      }),
+    ),
+  },
+  createQueryBuilder: jest.fn(() => ({
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn(),
+  })),
+}
+
+const mockDocumentVersionRepository = {
+  create: jest.fn(),
+  save: jest.fn(),
+  findOne: jest.fn(),
+  find: jest.fn(),
+  softDelete: jest.fn(),
+  createQueryBuilder: jest.fn(() => ({
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn(),
+  })),
+}
+
+const mockOcrExtractionService = {
+  extractText: jest.fn(),
+}
+
+// NEW: Mock TaggingService
+const mockTaggingService = {
+  findOrCreateTags: jest.fn(),
+}
+
+describe("DocumentHistoryService", () => {
+  let service: DocumentHistoryService
+  let documentRepository: Repository<Document>
+  let documentVersionRepository: Repository<DocumentVersion>
+  let ocrExtractionService: OcrExtractionService
+  let taggingService: TaggingService // NEW
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DocumentHistoryService,
+        {
+          provide: getRepositoryToken(Document),
+          useValue: mockDocumentRepository,
+        },
+        {
+          provide: getRepositoryToken(DocumentVersion),
+          useValue: mockDocumentVersionRepository,
+        },
+        {
+          provide: OcrExtractionService,
+          useValue: mockOcrExtractionService,
+        },
+        {
+          provide: TaggingService, // NEW
+          useValue: mockTaggingService,
+        },
+      ],
+    }).compile()
+
+    service = module.get<DocumentHistoryService>(DocumentHistoryService)
+    documentRepository = module.get<Repository<Document>>(getRepositoryToken(Document))
+    documentVersionRepository = module.get<Repository<DocumentVersion>>(getRepositoryToken(DocumentVersion))
+    ocrExtractionService = module.get<OcrExtractionService>(OcrExtractionService)
+    taggingService = module.get<TaggingService>(TaggingService) // NEW
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  describe("createDocument", () => {
+    it("should create a new document and its initial version, performing OCR and associating tags", async () => {
+      const createDto: CreateDocumentDto = {
+        name: "Test Document",
+        documentType: DocumentType.SURVEY_PLAN,
+        uploadedBy: "user-123",
+        documentUrl: "http://example.com/doc1.pdf",
+        riskReport: { score: 50, details: "medium risk" },
+        riskStatus: RiskStatus.MEDIUM_RISK,
+        tagNames: ["legal", "property"], // NEW
+      }
+      const extractedText = "OCR text from doc1.pdf"
+      const mockTags: Tag[] = [{ id: "tag-1", name: "legal" } as Tag, { id: "tag-2", name: "property" } as Tag] // NEW
+
+      mockOcrExtractionService.extractText.mockResolvedValue(extractedText)
+      mockTaggingService.findOrCreateTags.mockResolvedValue(mockTags) // NEW
+
+      const mockDocument = {
+        id: "doc-uuid",
+        ...createDto,
+        currentVersionId: null,
+        currentVersion: null,
+        versions: [],
+        tags: mockTags, // NEW
+      }
+      const mockVersion = {
+        id: "version-uuid",
+        documentId: "doc-uuid",
+        versionNumber: 1,
+        ...createDto,
+        document: mockDocument,
+        extractedText,
+      }
+
+      mockDocumentRepository.create.mockReturnValue(mockDocument)
+      mockDocumentVersionRepository.create.mockReturnValue(mockVersion)
+      mockDocumentRepository.manager.transaction.mockImplementation(async (cb) => {
+        const entityManager = {
+          save: jest.fn((entity) => {
+            if (entity instanceof Document) return { ...entity, id: "doc-uuid" }
+            if (entity instanceof DocumentVersion) return { ...entity, id: "version-uuid" }
+            return entity
+          }),
+          softDelete: jest.fn(),
+        }
+        return cb(entityManager)
+      })
+
+      const result = await service.createDocument(createDto)
+
+      expect(ocrExtractionService.extractText).toHaveBeenCalledWith(createDto.documentUrl)
+      expect(mockTaggingService.findOrCreateTags).toHaveBeenCalledWith(createDto.tagNames) // NEW
+      expect(mockDocumentVersionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extractedText: extractedText,
+        }),
+      )
+      expect(mockDocumentRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: mockTags, // NEW
+        }),
+      )
+      expect(result.currentVersion.extractedText).toBe(extractedText)
+      expect(result.tags).toEqual(mockTags) // NEW
+    })
+
+    it("should create a new document and use provided extractedText without performing OCR and no tags", async () => {
+      const createDto: CreateDocumentDto = {
+        name: "Test Document",
+        documentType: DocumentType.SURVEY_PLAN,
+        uploadedBy: "user-123",
+        documentUrl: "http://example.com/doc1.pdf",
+        riskReport: { score: 50, details: "medium risk" },
+        riskStatus: RiskStatus.MEDIUM_RISK,
+        extractedText: "Pre-provided OCR text",
+        tagNames: [], // NEW: No tags
+      }
+      const extractedText = "Pre-provided OCR text"
+
+      mockOcrExtractionService.extractText.mockResolvedValue("Should not be called")
+      mockTaggingService.findOrCreateTags.mockResolvedValue([]) // NEW
+
+      const mockDocument = {
+        id: "doc-uuid",
+        ...createDto,
+        currentVersionId: null,
+        currentVersion: null,
+        versions: [],
+        tags: [], // NEW
+      }
+      const mockVersion = {
+        id: "version-uuid",
+        documentId: "doc-uuid",
+        versionNumber: 1,
+        ...createDto,
+        document: mockDocument,
+        extractedText,
+      }
+
+      mockDocumentRepository.create.mockReturnValue(mockDocument)
+      mockDocumentVersionRepository.create.mockReturnValue(mockVersion)
+      mockDocumentRepository.manager.transaction.mockImplementation(async (cb) => {
+        const entityManager = {
+          save: jest.fn((entity) => {
+            if (entity instanceof Document) return { ...entity, id: "doc-uuid" }
+            if (entity instanceof DocumentVersion) return { ...entity, id: "version-uuid" }
+            return entity
+          }),
+          softDelete: jest.fn(),
+        }
+        return cb(entityManager)
+      })
+
+      const result = await service.createDocument(createDto)
+
+      expect(ocrExtractionService.extractText).not.toHaveBeenCalled()
+      expect(mockTaggingService.findOrCreateTags).toHaveBeenCalledWith([]) // NEW
+      expect(mockDocumentVersionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extractedText: extractedText,
+        }),
+      )
+      expect(result.currentVersion.extractedText).toBe(extractedText)
+      expect(result.tags).toEqual([]) // NEW
+    })
+  })
+
+  describe("findAllDocuments", () => {
+    it("should return all current documents with pagination, filters, and tags", async () => {
+      const docList = [
+        { id: "doc-1", name: "Doc A", currentVersion: { id: "v1", versionNumber: 1 }, tags: [{ name: "legal" }] },
+      ]
+      mockDocumentRepository.createQueryBuilder().getManyAndCount.mockResolvedValue([docList, 1])
+
+      const filterDto: FilterDocumentsDto = {
+        name: "Doc",
+        documentType: DocumentType.SURVEY_PLAN,
+        tag: "legal", // NEW
+        page: 1,
+        limit: 10,
+      }
+      const result = await service.findAllDocuments(filterDto)
+
+      const queryBuilderMock = mockDocumentRepository.createQueryBuilder()
+      expect(queryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith("document.currentVersion", "currentVersion")
+      expect(queryBuilderMock.leftJoinAndSelect).toHaveBeenCalledWith("document.tags", "tags") // NEW
+      expect(queryBuilderMock.where).toHaveBeenCalledWith("document.deletedAt IS NULL")
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("document.name ILIKE :name", { name: "%Doc%" })
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("document.documentType = :documentType", {
+        documentType: DocumentType.SURVEY_PLAN,
+      })
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("tags.name ILIKE :tag", { tag: "%legal%" }) // NEW
+      expect(queryBuilderMock.orderBy).toHaveBeenCalledWith("document.createdAt", "DESC")
+      expect(queryBuilderMock.skip).toHaveBeenCalledWith(0)
+      expect(queryBuilderMock.take).toHaveBeenCalledWith(10)
+      expect(result).toEqual({ data: docList, total: 1 })
+    })
+  })
+
+  describe("findOneDocument", () => {
+    it("should return a document with its current version and tags if found", async () => {
+      const document = {
+        id: "doc-1",
+        name: "Doc A",
+        currentVersion: { id: "v1", versionNumber: 1 },
+        tags: [{ name: "legal" }],
+      }
+      mockDocumentRepository.findOne.mockResolvedValue(document)
+
+      const result = await service.findOneDocument("doc-1")
+      expect(mockDocumentRepository.findOne).toHaveBeenCalledWith({
+        where: { id: "doc-1", deletedAt: null },
+        relations: ["currentVersion", "tags"], // NEW
+      })
+      expect(result).toEqual(document)
+    })
+
+    it("should return undefined if document not found", async () => {
+      mockDocumentRepository.findOne.mockResolvedValue(undefined)
+      const result = await service.findOneDocument("non-existent-id")
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("updateDocument", () => {
+    it("should update document metadata, create a new version, perform OCR, and update tags", async () => {
+      const existingDocument = {
+        id: "doc-1",
+        name: "Old Name",
+        documentType: DocumentType.SURVEY_PLAN,
+        currentVersion: {
+          id: "v1",
+          versionNumber: 1,
+          uploadedBy: "user-old",
+          documentUrl: "old.pdf",
+          riskReport: {},
+          riskStatus: RiskStatus.LOW_RISK,
+          extractedText: "old text",
+        },
+        currentVersionId: "v1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        tags: [{ id: "tag-1", name: "old-tag" }], // Existing tags
+      }
+      const updateDto: UpdateDocumentDto = {
+        name: "New Name",
+        uploadedBy: "user-new",
+        documentUrl: "new.pdf",
+        riskReport: { score: 80 },
+        riskStatus: RiskStatus.HIGH_RISK,
+        uploadNotes: "Updated file and risk",
+        tagNames: ["new-tag", "updated-tag"], // New tags
+      }
+      const extractedText = "OCR text from new.pdf"
+      const newTags: Tag[] = [{ id: "tag-3", name: "new-tag" } as Tag, { id: "tag-4", name: "updated-tag" } as Tag] // NEW
+
+      mockDocumentRepository.findOne.mockResolvedValue(existingDocument)
+      mockOcrExtractionService.extractText.mockResolvedValue(extractedText)
+      mockTaggingService.findOrCreateTags.mockResolvedValue(newTags) // NEW
+
+      const newVersionMock = {
+        id: "v2",
+        versionNumber: 2,
+        uploadedBy: "user-new",
+        documentUrl: "new.pdf",
+        riskReport: { score: 80 },
+        riskStatus: RiskStatus.HIGH_RISK,
+        uploadNotes: "Updated file and risk",
+        extractedText,
+      }
+
+      mockDocumentVersionRepository.create.mockReturnValue(newVersionMock)
+      mockDocumentRepository.manager.transaction.mockImplementation(async (cb) => {
+        const entityManager = {
+          save: jest.fn((entity) => {
+            if (entity instanceof Document) return { ...entity, currentVersion: newVersionMock, currentVersionId: "v2" }
+            if (entity instanceof DocumentVersion) return { ...entity, id: "v2" }
+            return entity
+          }),
+          softDelete: jest.fn(),
+        }
+        return cb(entityManager)
+      })
+
+      const result = await service.updateDocument("doc-1", updateDto)
+
+      expect(ocrExtractionService.extractText).toHaveBeenCalledWith(updateDto.documentUrl)
+      expect(mockTaggingService.findOrCreateTags).toHaveBeenCalledWith(updateDto.tagNames) // NEW
+      expect(mockDocumentVersionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extractedText: extractedText,
+        }),
+      )
+      expect(result.name).toBe("New Name")
+      expect(result.currentVersion.id).toBe("v2")
+      expect(result.currentVersion.versionNumber).toBe(2)
+      expect(result.currentVersion.extractedText).toBe(extractedText)
+      expect(result.tags).toEqual(newTags) // NEW
+    })
+
+    it("should update document metadata and use provided extractedText without performing OCR and no tags", async () => {
+      const existingDocument = {
+        id: "doc-1",
+        name: "Old Name",
+        documentType: DocumentType.SURVEY_PLAN,
+        currentVersion: {
+          id: "v1",
+          versionNumber: 1,
+          uploadedBy: "user-old",
+          documentUrl: "old.pdf",
+          riskReport: {},
+          riskStatus: RiskStatus.LOW_RISK,
+          extractedText: "old text",
+        },
+        currentVersionId: "v1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        tags: [{ id: "tag-1", name: "old-tag" }],
+      }
+      const updateDto: UpdateDocumentDto = {
+        name: "New Name",
+        uploadedBy: "user-new",
+        documentUrl: "new.pdf",
+        riskReport: { score: 80 },
+        riskStatus: RiskStatus.HIGH_RISK,
+        extractedText: "Pre-provided OCR text for update",
+        tagNames: [], // NEW: No tags
+      }
+      const extractedText = "Pre-provided OCR text for update"
+
+      mockDocumentRepository.findOne.mockResolvedValue(existingDocument)
+      mockOcrExtractionService.extractText.mockResolvedValue("Should not be called")
+      mockTaggingService.findOrCreateTags.mockResolvedValue([]) // NEW
+
+      const newVersionMock = {
+        id: "v2",
+        versionNumber: 2,
+        uploadedBy: "user-new",
+        documentUrl: "new.pdf",
+        riskReport: { score: 80 },
+        riskStatus: RiskStatus.HIGH_RISK,
+        extractedText,
+      }
+
+      mockDocumentVersionRepository.create.mockReturnValue(newVersionMock)
+      mockDocumentRepository.manager.transaction.mockImplementation(async (cb) => {
+        const entityManager = {
+          save: jest.fn((entity) => {
+            if (entity instanceof Document) return { ...entity, currentVersion: newVersionMock, currentVersionId: "v2" }
+            if (entity instanceof DocumentVersion) return { ...entity, id: "v2" }
+            return entity
+          }),
+          softDelete: jest.fn(),
+        }
+        return cb(entityManager)
+      })
+
+      const result = await service.updateDocument("doc-1", updateDto)
+
+      expect(ocrExtractionService.extractText).not.toHaveBeenCalled()
+      expect(mockTaggingService.findOrCreateTags).toHaveBeenCalledWith([]) // NEW
+      expect(mockDocumentVersionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extractedText: extractedText,
+        }),
+      )
+      expect(result.currentVersion.extractedText).toBe(extractedText)
+      expect(result.tags).toEqual([]) // NEW
+    })
+
+    it("should throw BadRequestException if required new version fields are missing", async () => {
+      const existingDocument = {
+        id: "doc-1",
+        name: "Old Name",
+        documentType: DocumentType.SURVEY_PLAN,
+        currentVersion: {
+          id: "v1",
+          versionNumber: 1,
+          uploadedBy: "user-old",
+          documentUrl: "old.pdf",
+          riskReport: {},
+          riskStatus: RiskStatus.LOW_RISK,
+        },
+        currentVersionId: "v1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        tags: [],
+      }
+      const updateDto: UpdateDocumentDto = {
+        name: "New Name",
+        uploadedBy: "user-new",
+        documentUrl: "new.pdf",
+        riskReport: { score: 80 },
+        riskStatus: undefined, // Missing required field
+      }
+
+      mockDocumentRepository.findOne.mockResolvedValue(existingDocument)
+      mockDocumentVersionRepository.create.mockReturnValue({ ...updateDto, versionNumber: 2 })
+
+      await expect(service.updateDocument("doc-1", updateDto)).rejects.toThrow(BadRequestException)
+    })
+
+    it("should return undefined if document not found for update", async () => {
+      mockDocumentRepository.findOne.mockResolvedValue(undefined)
+      const updateDto: UpdateDocumentDto = {
+        uploadedBy: "user-new",
+        documentUrl: "new.pdf",
+        riskReport: { score: 80 },
+        riskStatus: RiskStatus.HIGH_RISK,
+      }
+      const result = await service.updateDocument("non-existent-id", updateDto)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("removeDocument", () => {
+    it("should soft delete a document and its versions", async () => {
+      const document = { id: "doc-1", name: "Test Doc" }
+      mockDocumentRepository.findOne.mockResolvedValue(document)
+      mockDocumentRepository.manager.transaction.mockImplementation(async (cb) => {
+        const entityManager = {
+          save: jest.fn(),
+          softDelete: jest.fn().mockResolvedValue({ affected: 1 }),
+        }
+        return cb(entityManager)
+      })
+
+      const result = await service.removeDocument("doc-1")
+      expect(mockDocumentRepository.findOne).toHaveBeenCalledWith({ where: { id: "doc-1", deletedAt: null } })
+      expect(mockDocumentRepository.manager.transaction).toHaveBeenCalled()
+      expect(mockDocumentRepository.manager.transaction().softDelete).toHaveBeenCalledWith(DocumentVersion, {
+        document: { id: "doc-1" },
+      })
+      expect(mockDocumentRepository.manager.transaction().softDelete).toHaveBeenCalledWith(Document, "doc-1")
+      expect(result).toBe(true)
+    })
+
+    it("should return false if document not found for deletion", async () => {
+      mockDocumentRepository.findOne.mockResolvedValue(undefined)
+      const result = await service.removeDocument("non-existent-id")
+      expect(result).toBe(false)
+    })
+  })
+
+  describe("findDocumentVersions", () => {
+    it("should return all versions for a document with filters and pagination", async () => {
+      const versions = [
+        { id: "v1", versionNumber: 1 },
+        { id: "v2", versionNumber: 2 },
+      ]
+      mockDocumentVersionRepository.createQueryBuilder().getManyAndCount.mockResolvedValue([versions, 2])
+
+      const filterDto: FilterDocumentVersionsDto = {
+        versionNumber: 1,
+        uploadedBy: "user-123",
+        riskStatus: RiskStatus.LOW_RISK,
+        page: 1,
+        limit: 5,
+      }
+      const result = await service.findDocumentVersions("doc-1", filterDto)
+
+      const queryBuilderMock = mockDocumentVersionRepository.createQueryBuilder()
+      expect(queryBuilderMock.where).toHaveBeenCalledWith("version.documentId = :documentId", { documentId: "doc-1" })
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("version.versionNumber = :versionNumber", {
+        versionNumber: 1,
+      })
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("version.uploadedBy = :uploadedBy", {
+        uploadedBy: "user-123",
+      })
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("version.riskStatus = :riskStatus", {
+        riskStatus: RiskStatus.LOW_RISK,
+      })
+      expect(queryBuilderMock.orderBy).toHaveBeenCalledWith("version.createdAt", "DESC")
+      expect(queryBuilderMock.skip).toHaveBeenCalledWith(0)
+      expect(queryBuilderMock.take).toHaveBeenCalledWith(5)
+      expect(result).toEqual({ data: versions, total: 2 })
+    })
+  })
+
+  describe("findSpecificDocumentVersion", () => {
+    it("should return a specific version if found", async () => {
+      const version = { id: "v1", versionNumber: 1, documentId: "doc-1" }
+      mockDocumentVersionRepository.findOne.mockResolvedValue(version)
+
+      const result = await service.findSpecificDocumentVersion("doc-1", 1)
+      expect(mockDocumentVersionRepository.findOne).toHaveBeenCalledWith({
+        where: { document: { id: "doc-1" }, versionNumber: 1 },
+      })
+      expect(result).toEqual(version)
+    })
+
+    it("should return undefined if specific version not found", async () => {
+      mockDocumentVersionRepository.findOne.mockResolvedValue(undefined)
+      const result = await service.findSpecificDocumentVersion("doc-1", 99)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("checkDocumentExists", () => {
+    it("should return true if document exists", async () => {
+      mockDocumentRepository.count.mockResolvedValue(1)
+      const result = await service.checkDocumentExists("doc-1")
+      expect(result).toBe(true)
+    })
+
+    it("should return false if document does not exist", async () => {
+      mockDocumentRepository.count.mockResolvedValue(0)
+      const result = await service.checkDocumentExists("non-existent-id")
+      expect(result).toBe(false)
+    })
+  })
+})
+
+describe("DocumentHistoryController", () => {
+  let controller: DocumentHistoryController
+  let service: DocumentHistoryService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DocumentHistoryController],
+      providers: [
+        {
+          provide: DocumentHistoryService,
+          useValue: {
+            createDocument: jest.fn(),
+            findAllDocuments: jest.fn(),
+            findOneDocument: jest.fn(),
+            updateDocument: jest.fn(),
+            removeDocument: jest.fn(),
+            findDocumentVersions: jest.fn(),
+            findSpecificDocumentVersion: jest.fn(),
+            checkDocumentExists: jest.fn(),
+          },
+        },
+      ],
+    }).compile()
+
+    controller = module.get<DocumentHistoryController>(DocumentHistoryController)
+    service = module.get<DocumentHistoryService>(DocumentHistoryService)
+  })
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined()
+  })
+
+  describe("create", () => {
+    it("should create a document and its initial version with tags", async () => {
+      const createDto: CreateDocumentDto = {
+        name: "New Doc",
+        documentType: DocumentType.AGREEMENT,
+        uploadedBy: "user-abc",
+        documentUrl: "url.pdf",
+        riskReport: {},
+        riskStatus: RiskStatus.NO_RISK,
+        extractedText: "Some extracted text",
+        tagNames: ["contract", "legal"], // NEW
+      }
+      const expectedDoc = {
+        id: "doc-1",
+        ...createDto,
+        currentVersion: { id: "v1", versionNumber: 1, extractedText: "Some extracted text" },
+        tags: [{ id: "tag-1", name: "contract" }], // Simplified mock tags
+      }
+      jest.spyOn(service, "createDocument").mockResolvedValue(expectedDoc as Document)
+
+      const result = await controller.create(createDto)
+      expect(service.createDocument).toHaveBeenCalledWith(createDto)
+      expect(result).toEqual(expectedDoc)
+    })
+  })
+
+  describe("findAllCurrent", () => {
+    it("should return all current documents with tag filter", async () => {
+      const filterDto: FilterDocumentsDto = { page: 1, limit: 10, tag: "legal" } // NEW
+      const docList = {
+        data: [{ id: "doc-1", name: "Doc A", currentVersion: { id: "v1" }, tags: [{ name: "legal" }] }],
+        total: 1,
+      }
+      jest.spyOn(service, "findAllDocuments").mockResolvedValue(docList as any)
+
+      const result = await controller.findAllCurrent(filterDto)
+      expect(service.findAllDocuments).toHaveBeenCalledWith(filterDto)
+      expect(result).toEqual(docList)
+    })
+  })
+
+  describe("findOne", () => {
+    it("should return a single document with its current version and tags", async () => {
+      const document = {
+        id: "doc-1",
+        name: "Doc A",
+        currentVersion: { id: "v1" },
+        tags: [{ name: "finance" }],
+      }
+      jest.spyOn(service, "findOneDocument").mockResolvedValue(document as Document)
+
+      const result = await controller.findOne("doc-1")
+      expect(service.findOneDocument).toHaveBeenCalledWith("doc-1")
+      expect(result).toEqual(document)
+    })
+
+    it("should throw NotFoundException if document not found", async () => {
+      jest.spyOn(service, "findOneDocument").mockResolvedValue(undefined)
+      await expect(controller.findOne("non-existent-id")).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe("update", () => {
+    it("should update a document and create a new version with tags", async () => {
+      const updateDto: UpdateDocumentDto = {
+        uploadedBy: "user-new",
+        documentUrl: "new.pdf",
+        riskReport: { score: 70 },
+        riskStatus: RiskStatus.HIGH_RISK,
+        extractedText: "Updated extracted text",
+        tagNames: ["updated-tag"], // NEW
+      }
+      const updatedDoc = {
+        id: "doc-1",
+        name: "Updated Doc",
+        currentVersion: { id: "v2", versionNumber: 2, extractedText: "Updated extracted text" },
+        tags: [{ id: "tag-2", name: "updated-tag" }], // Simplified mock tags
+      }
+      jest.spyOn(service, "updateDocument").mockResolvedValue(updatedDoc as Document)
+
+      const result = await controller.update("doc-1", updateDto)
+      expect(service.updateDocument).toHaveBeenCalledWith("doc-1", updateDto)
+      expect(result).toEqual(updatedDoc)
+    })
+
+    it("should throw NotFoundException if document not found for update", async () => {
+      jest.spyOn(service, "updateDocument").mockResolvedValue(undefined)
+      await expect(controller.update("non-existent-id", {} as UpdateDocumentDto)).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe("remove", () => {
+    it("should soft delete a document and its versions", async () => {
+      jest.spyOn(service, "removeDocument").mockResolvedValue(true)
+      const result = await controller.remove("doc-1")
+      expect(service.removeDocument).toHaveBeenCalledWith("doc-1")
+      expect(result).toBeUndefined()
+    })
+
+    it("should throw NotFoundException if document not found for removal", async () => {
+      jest.spyOn(service, "removeDocument").mockResolvedValue(false)
+      await expect(controller.remove("non-existent-id")).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe("getDocumentVersions", () => {
+    it("should return all versions for a document", async () => {
+      const versions = { data: [{ id: "v1", versionNumber: 1 }], total: 1 }
+      jest.spyOn(service, "checkDocumentExists").mockResolvedValue(true)
+      jest.spyOn(service, "findDocumentVersions").mockResolvedValue(versions as any)
+
+      const result = await controller.getDocumentVersions("doc-1", {})
+      expect(service.checkDocumentExists).toHaveBeenCalledWith("doc-1")
+      expect(service.findDocumentVersions).toHaveBeenCalledWith("doc-1", {})
+      expect(result).toEqual(versions)
+    })
+
+    it("should throw NotFoundException if document not found for versions", async () => {
+      jest.spyOn(service, "checkDocumentExists").mockResolvedValue(false)
+      await expect(controller.getDocumentVersions("non-existent-id", {})).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe("getSpecificDocumentVersion", () => {
+    it("should return a specific version of a document", async () => {
+      const version = { id: "v1", versionNumber: 1, documentId: "doc-1" }
+      jest.spyOn(service, "findSpecificDocumentVersion").mockResolvedValue(version as DocumentVersion)
+
+      const result = await controller.getSpecificDocumentVersion("doc-1", 1)
+      expect(service.findSpecificDocumentVersion).toHaveBeenCalledWith("doc-1", 1)
+      expect(result).toEqual(version)
+    })
+
+    it("should throw NotFoundException if specific version not found", async () => {
+      jest.spyOn(service, "findSpecificDocumentVersion").mockResolvedValue(undefined)
+      await expect(controller.getSpecificDocumentVersion("doc-1", 99)).rejects.toThrow(NotFoundException)
+    })
+  })
+})

--- a/backend/src/document-history/dto/create-document.dto.ts
+++ b/backend/src/document-history/dto/create-document.dto.ts
@@ -1,0 +1,85 @@
+import { IsString, IsNotEmpty, IsOptional, IsEnum, IsUUID, IsUrl, IsObject, IsArray } from "class-validator"
+import { DocumentType } from "../enums/document-type.enum"
+import { RiskStatus } from "../enums/risk-status.enum"
+import { ApiProperty } from "@nestjs/swagger"
+
+export class CreateDocumentDto {
+  @ApiProperty({ description: "Name of the document" })
+  @IsNotEmpty()
+  @IsString()
+  name: string
+
+  @ApiProperty({ description: "Description of the document", required: false })
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @ApiProperty({ enum: DocumentType, description: "Type of the document (e.g., survey_plan, agreement)" })
+  @IsNotEmpty()
+  @IsEnum(DocumentType)
+  documentType: DocumentType
+
+  @ApiProperty({ description: "ID of the user or entity that owns this document", required: false, format: "uuid" })
+  @IsOptional()
+  @IsUUID()
+  ownerId?: string
+
+  @ApiProperty({
+    description: "ID of the property owner associated with this document",
+    required: false,
+    format: "uuid",
+  }) // NEW
+  @IsOptional()
+  @IsUUID()
+  propertyOwnerId?: string // NEW
+
+  @ApiProperty({ description: "Array of tag names to associate with the document", type: [String], required: false })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tagNames?: string[]
+
+  // Fields for the initial DocumentVersion
+  @ApiProperty({ description: "ID of the user who uploaded this initial version", format: "uuid" })
+  @IsNotEmpty()
+  @IsUUID()
+  uploadedBy: string
+
+  @ApiProperty({ description: "URL or path to the actual document file for this version" })
+  @IsNotEmpty()
+  @IsString()
+  @IsUrl({ require_tld: false })
+  documentUrl: string
+
+  @ApiProperty({
+    description: "Structured JSON data of the risk report for this version",
+    type: "object",
+    additionalProperties: true,
+  })
+  @IsNotEmpty()
+  @IsObject()
+  riskReport: Record<string, any>
+
+  @ApiProperty({ description: "A brief summary of the risks identified in this version", required: false })
+  @IsOptional()
+  @IsString()
+  riskSummary?: string
+
+  @ApiProperty({ enum: RiskStatus, description: "Overall risk status for this document version" })
+  @IsNotEmpty()
+  @IsEnum(RiskStatus)
+  riskStatus: RiskStatus
+
+  @ApiProperty({ description: "Notes about this initial version upload", required: false })
+  @IsOptional()
+  @IsString()
+  uploadNotes?: string
+
+  @ApiProperty({
+    description: "Optional pre-extracted text content from OCR. If not provided, OCR will be performed.",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  extractedText?: string
+}

--- a/backend/src/document-history/dto/filter-document-versions.dto.ts
+++ b/backend/src/document-history/dto/filter-document-versions.dto.ts
@@ -1,0 +1,60 @@
+{
+  ;`import { IsOptional, IsEnum, IsString, IsNumber, Min, Max, IsDateString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { RiskStatus } from '../enums/risk-status.enum';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FilterDocumentVersionsDto {
+  @ApiProperty({ description: 'Filter by specific version number', required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  versionNumber?: number;
+
+  @ApiProperty({ description: 'Filter by user ID who uploaded the version', required: false, format: 'uuid' })
+  @IsOptional()
+  @IsString()
+  uploadedBy?: string;
+
+  @ApiProperty({ enum: RiskStatus, description: 'Filter by risk status of the version', required: false })
+  @IsOptional()
+  @IsEnum(RiskStatus)
+  riskStatus?: RiskStatus;
+
+  @ApiProperty({ description: 'Filter by version creation date (start date)', required: false, format: 'date-time' })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiProperty({ description: 'Filter by version creation date (end date)', required: false, format: 'date-time' })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @ApiProperty({ description: 'Page number for pagination', required: false, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number;
+
+  @ApiProperty({ description: 'Number of items per page', required: false, default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+
+  @ApiProperty({ description: 'Field to sort by (e.g., createdAt, versionNumber)', required: false, default: 'createdAt' })
+  @IsOptional()
+  @IsString()
+  sortBy?: string;
+
+  @ApiProperty({ enum: ['ASC', 'DESC'], description: 'Sort order (ASC or DESC)', required: false, default: 'DESC' })
+  @IsOptional()
+  @IsEnum(['ASC', 'DESC'])
+  sortOrder?: 'ASC' | 'DESC';
+}`
+}

--- a/backend/src/document-history/dto/filter-documents.dto.ts
+++ b/backend/src/document-history/dto/filter-documents.dto.ts
@@ -1,0 +1,56 @@
+import { IsOptional, IsEnum, IsString, IsNumber, Min, Max, IsUUID } from "class-validator" // NEW: IsUUID
+import { Type } from "class-transformer"
+import { DocumentType } from "../enums/document-type.enum"
+import { ApiProperty } from "@nestjs/swagger"
+
+export class FilterDocumentsDto {
+  @ApiProperty({ description: "Filter by document name (partial match)", required: false })
+  @IsOptional()
+  @IsString()
+  name?: string
+
+  @ApiProperty({ enum: DocumentType, description: "Filter by document type", required: false })
+  @IsOptional()
+  @IsEnum(DocumentType)
+  documentType?: DocumentType
+
+  @ApiProperty({ description: "Filter by document owner ID", required: false, format: "uuid" })
+  @IsOptional()
+  @IsString()
+  ownerId?: string
+
+  @ApiProperty({ description: "Filter by property owner ID", required: false, format: "uuid" }) // NEW
+  @IsOptional()
+  @IsUUID()
+  propertyOwnerId?: string // NEW
+
+  @ApiProperty({ description: "Filter by a specific tag name associated with the document", required: false })
+  @IsOptional()
+  @IsString()
+  tag?: string
+
+  @ApiProperty({ description: "Page number for pagination", required: false, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number
+
+  @ApiProperty({ description: "Number of items per page", required: false, default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number
+
+  @ApiProperty({ description: "Field to sort by (e.g., createdAt, name)", required: false, default: "createdAt" })
+  @IsOptional()
+  @IsString()
+  sortBy?: string
+
+  @ApiProperty({ enum: ["ASC", "DESC"], description: "Sort order (ASC or DESC)", required: false, default: "DESC" })
+  @IsOptional()
+  @IsEnum(["ASC", "DESC"])
+  sortOrder?: "ASC" | "DESC"
+}

--- a/backend/src/document-history/dto/update-document.dto.ts
+++ b/backend/src/document-history/dto/update-document.dto.ts
@@ -1,0 +1,92 @@
+import { PartialType } from "@nestjs/swagger"
+import { CreateDocumentDto } from "./create-document.dto"
+import { IsString, IsNotEmpty, IsOptional, IsEnum, IsUUID, IsUrl, IsObject, IsArray } from "class-validator"
+import { DocumentType } from "../enums/document-type.enum"
+import { RiskStatus } from "../enums/risk-status.enum"
+import { ApiProperty } from "@nestjs/swagger"
+
+export class UpdateDocumentDto extends PartialType(CreateDocumentDto) {
+  @ApiProperty({ description: "Updated name of the document", required: false })
+  @IsOptional()
+  @IsString()
+  name?: string
+
+  @ApiProperty({ description: "Updated description of the document", required: false })
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @ApiProperty({ enum: DocumentType, description: "Updated type of the document", required: false })
+  @IsOptional()
+  @IsEnum(DocumentType)
+  documentType?: DocumentType
+
+  @ApiProperty({
+    description: "Updated ID of the user or entity that owns this document",
+    required: false,
+    format: "uuid",
+  })
+  @IsOptional()
+  @IsUUID()
+  ownerId?: string
+
+  @ApiProperty({
+    description: "Updated ID of the property owner associated with this document",
+    required: false,
+    format: "uuid",
+  }) // NEW
+  @IsOptional()
+  @IsUUID()
+  propertyOwnerId?: string // NEW
+
+  @ApiProperty({ description: "Array of tag names to associate with the document", type: [String], required: false })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tagNames?: string[]
+
+  // Fields for the NEW DocumentVersion (these are required for a new version)
+  @ApiProperty({ description: "ID of the user who uploaded this new version", format: "uuid" })
+  @IsNotEmpty()
+  @IsUUID()
+  uploadedBy: string
+
+  @ApiProperty({ description: "URL or path to the actual document file for this new version" })
+  @IsNotEmpty()
+  @IsString()
+  @IsUrl({ require_tld: false })
+  documentUrl: string
+
+  @ApiProperty({
+    description: "Structured JSON data of the risk report for this new version",
+    type: "object",
+    additionalProperties: true,
+  })
+  @IsNotEmpty()
+  @IsObject()
+  riskReport: Record<string, any>
+
+  @ApiProperty({ description: "A brief summary of the risks identified in this new version", required: false })
+  @IsOptional()
+  @IsString()
+  riskSummary?: string
+
+  @ApiProperty({ enum: RiskStatus, description: "Overall risk status for this new document version" })
+  @IsNotEmpty()
+  @IsEnum(RiskStatus)
+  riskStatus: RiskStatus
+
+  @ApiProperty({ description: "Notes about this new version upload or edit", required: false })
+  @IsOptional()
+  @IsString()
+  uploadNotes?: string
+
+  @ApiProperty({
+    description:
+      "Optional pre-extracted text content from OCR for the new version. If not provided, OCR will be performed.",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  extractedText?: string
+}

--- a/backend/src/document-history/entities/document-version.entity.ts
+++ b/backend/src/document-history/entities/document-version.entity.ts
@@ -1,0 +1,70 @@
+{
+  ;`import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  DeleteDateColumn,
+} from 'typeorm';
+import { Document } from './document.entity';
+import { RiskStatus } from '../enums/risk-status.enum';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('document_versions')
+export class DocumentVersion {
+  @ApiProperty({ description: 'Unique identifier for the document version' })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({ description: 'Foreign key to the parent document', format: 'uuid' })
+  @Column({ type: 'uuid' })
+  documentId: string;
+
+  @ApiProperty({ type: () => Document, description: 'The parent document this version belongs to' })
+  @ManyToOne(() => Document, (document) => document.versions, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'documentId' })
+  document: Document;
+
+  @ApiProperty({ description: 'Sequential version number for this document' })
+  @Column({ type: 'int' })
+  versionNumber: number;
+
+  @ApiProperty({ description: 'ID of the user who uploaded/edited this version', format: 'uuid' })
+  @Column({ type: 'uuid' })
+  uploadedBy: string;
+
+  @ApiProperty({ description: 'Notes about this specific version upload or edit', nullable: true })
+  @Column({ type: 'text', nullable: true })
+  uploadNotes?: string;
+
+  @ApiProperty({ description: 'URL or path to the actual document file for this version' })
+  @Column({ type: 'varchar', length: 512 })
+  documentUrl: string;
+
+  @ApiProperty({ description: 'Structured JSON data of the risk report for this version', type: 'object', additionalProperties: true })
+  @Column({ type: 'jsonb' })
+  riskReport: Record<string, any>;
+
+  @ApiProperty({ description: 'A brief summary of the risks identified in this version', nullable: true })
+  @Column({ type: 'text', nullable: true })
+  riskSummary?: string;
+
+  @ApiProperty({ enum: RiskStatus, description: 'Overall risk status for this document version' })
+  @Column({ type: 'enum', enum: RiskStatus })
+  riskStatus: RiskStatus;
+
+  @ApiProperty({ description: 'Extracted text content from the document using OCR', nullable: true })
+  @Column({ type: 'text', nullable: true })
+  extractedText?: string; // NEW FIELD
+
+  @ApiProperty({ description: 'Timestamp when this version was created' })
+  @CreateDateColumn({ type: 'timestamp with time zone', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Timestamp when this version was soft-deleted (if parent document is deleted)', nullable: true })
+  @DeleteDateColumn({ type: 'timestamp with time zone', nullable: true })
+  deletedAt?: Date;
+}`
+}

--- a/backend/src/document-history/entities/document.entity.ts
+++ b/backend/src/document-history/entities/document.entity.ts
@@ -1,0 +1,103 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+  OneToMany,
+  OneToOne,
+  JoinColumn,
+  ManyToMany,
+  JoinTable,
+  ManyToOne, // NEW
+} from "typeorm"
+import { DocumentType } from "../enums/document-type.enum"
+import { DocumentVersion } from "./document-version.entity"
+import { Tag } from "../../tagging/entities/tag.entity"
+import { PropertyOwner } from "../../property-owner/entities/property-owner.entity" // NEW
+import { ApiProperty } from "@nestjs/swagger"
+
+@Entity("documents")
+export class Document {
+  @ApiProperty({ description: "Unique identifier for the document" })
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @ApiProperty({ description: "Name of the document" })
+  @Column({ type: "varchar", length: 255 })
+  name: string
+
+  @ApiProperty({ description: "Description of the document", nullable: true })
+  @Column({ type: "text", nullable: true })
+  description?: string
+
+  @ApiProperty({ enum: DocumentType, description: "Type of the document (e.g., survey_plan, agreement)" })
+  @Column({ type: "enum", enum: DocumentType })
+  documentType: DocumentType
+
+  @ApiProperty({ description: "ID of the user or entity that owns this document", nullable: true, format: "uuid" })
+  @Column({ type: "uuid", nullable: true })
+  ownerId?: string // e.g., the user who uploaded it, or a case ID
+
+  @ApiProperty({
+    description: "ID of the property owner associated with this document",
+    nullable: true,
+    format: "uuid",
+  }) // NEW
+  @Column({ type: "uuid", nullable: true })
+  propertyOwnerId?: string // NEW
+
+  @ApiProperty({ type: () => PropertyOwner, description: "The property owner associated with this document" }) // NEW
+  @ManyToOne(
+    () => PropertyOwner,
+    (propertyOwner) => propertyOwner.documents,
+    { onDelete: "SET NULL" },
+  ) // NEW
+  @JoinColumn({ name: "propertyOwnerId" })
+  owner: PropertyOwner // NEW
+
+  @ApiProperty({ description: "ID of the current active version of this document", nullable: true, format: "uuid" })
+  @Column({ type: "uuid", nullable: true })
+  currentVersionId?: string
+
+  @ApiProperty({ type: () => DocumentVersion, description: "The current active version of the document" })
+  @OneToOne(() => DocumentVersion, { eager: true, onDelete: "SET NULL" }) // Eager load current version
+  @JoinColumn({ name: "currentVersionId" })
+  currentVersion: DocumentVersion
+
+  @ApiProperty({ type: () => [DocumentVersion], description: "All historical versions of this document" })
+  @OneToMany(
+    () => DocumentVersion,
+    (version) => version.document,
+    { cascade: true },
+  )
+  versions: DocumentVersion[]
+
+  @ApiProperty({ type: () => [Tag], description: "Tags associated with the document", isArray: true })
+  @ManyToMany(
+    () => Tag,
+    (tag) => tag.documents,
+    { cascade: true },
+  )
+  @JoinTable({
+    name: "document_tags",
+    joinColumn: { name: "documentId", referencedColumnName: "id" },
+    inverseJoinColumn: { name: "tagId", referencedColumnName: "id" },
+  })
+  tags: Tag[]
+
+  @ApiProperty({ description: "Timestamp when the document was created" })
+  @CreateDateColumn({ type: "timestamp with time zone", default: () => "CURRENT_TIMESTAMP" })
+  createdAt: Date
+
+  @ApiProperty({
+    description: "Timestamp when the document was last updated (i.e., a new version was created or metadata changed)",
+  })
+  @UpdateDateColumn({ type: "timestamp with time zone", default: () => "CURRENT_TIMESTAMP" })
+  updatedAt: Date
+
+  @ApiProperty({ description: "Timestamp when the document was soft-deleted", nullable: true })
+  @DeleteDateColumn({ type: "timestamp with time zone", nullable: true })
+  deletedAt?: Date
+}

--- a/backend/src/document-history/enums/document-type.enum.ts
+++ b/backend/src/document-history/enums/document-type.enum.ts
@@ -1,0 +1,8 @@
+{
+  ;`export enum DocumentType {
+  SURVEY_PLAN = 'survey_plan',
+  AGREEMENT = 'agreement',
+  COURT_ORDER = 'court_order',
+  OTHER_DOCUMENT = 'other_document',
+}`
+}

--- a/backend/src/document-history/enums/risk-status.enum.ts
+++ b/backend/src/document-history/enums/risk-status.enum.ts
@@ -1,0 +1,10 @@
+{
+  ;`export enum RiskStatus {
+  LOW_RISK = 'low_risk',
+  MEDIUM_RISK = 'medium_risk',
+  HIGH_RISK = 'high_risk',
+  UNDER_REVIEW = 'under_review',
+  RESOLVED = 'resolved',
+  NO_RISK = 'no_risk',
+}`
+}


### PR DESCRIPTION
This pull request implements the `document-history` module for the Smalda backend. The module is responsible for tracking changes and activities related to land ownership documents, providing an audit trail for transparency and accountability.

**Key Features:**

* `DocumentHistoryEntity`: Defines the schema for storing historical actions on documents.
* `DocumentHistoryService`: Handles business logic for creating and retrieving history records.
* `DocumentHistoryController`: Exposes relevant endpoints to fetch document history by document ID.
* Integrated with `TypeORM` and `PostgreSQL`.
* Added basic validations and error handling.
* Unit test coverage for service layer.

**Next Steps / Future Enhancements:**

* Add pagination and filtering for history retrieval.
* Link actions to authenticated users for accountability.
* Emit history records on document update/create/delete actions via event emitters.

closes #68