### PR TITLE
feat(ocr-extraction): setup initial module structure and configuration

### DIFF
--- a/backend/src/ocr-extraction/dto/ocr-extraction.dto.ts
+++ b/backend/src/ocr-extraction/dto/ocr-extraction.dto.ts
@@ -1,0 +1,17 @@
+{
+  ;`import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OcrRequestDto {
+  @ApiProperty({ description: 'URL of the document (image or PDF) to perform OCR on' })
+  @IsNotEmpty()
+  @IsString()
+  @IsUrl({ require_tld: false }) // Use require_tld: false for placeholder.svg or local paths
+  documentUrl: string;
+}
+
+export class OcrResponseDto {
+  @ApiProperty({ description: 'The text extracted from the document by OCR' })
+  extractedText: string;
+}`
+}

--- a/backend/src/ocr-extraction/ocr-extraction.controller.ts
+++ b/backend/src/ocr-extraction/ocr-extraction.controller.ts
@@ -1,0 +1,23 @@
+{
+  ;`import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { OcrExtractionService } from './ocr-extraction.service';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { OcrRequestDto, OcrResponseDto } from './dto/ocr-extraction.dto';
+
+@ApiTags('OCR Extraction')
+@Controller('ocr-extraction')
+export class OcrExtractionController {
+  constructor(private readonly ocrExtractionService: OcrExtractionService) {}
+
+  @Post('extract')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Extract text from a document URL using OCR' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Text successfully extracted.', type: OcrResponseDto })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid input URL.' })
+  @ApiBody({ type: OcrRequestDto, description: 'URL of the document to perform OCR on' })
+  async extractText(@Body() ocrRequestDto: OcrRequestDto): Promise<OcrResponseDto> {
+    const extractedText = await this.ocrExtractionService.extractText(ocrRequestDto.documentUrl);
+    return { extractedText };
+  }
+}`
+}

--- a/backend/src/ocr-extraction/ocr-extraction.module.ts
+++ b/backend/src/ocr-extraction/ocr-extraction.module.ts
@@ -1,0 +1,12 @@
+{
+  ;`import { Module } from '@nestjs/common';
+import { OcrExtractionService } from './ocr-extraction.service';
+import { OcrExtractionController } from './ocr-extraction.controller';
+
+@Module({
+  controllers: [OcrExtractionController],
+  providers: [OcrExtractionService],
+  exports: [OcrExtractionService], // Export so DocumentHistoryModule can use it
+})
+export class OcrExtractionModule {}`
+}

--- a/backend/src/ocr-extraction/ocr-extraction.service.ts
+++ b/backend/src/ocr-extraction/ocr-extraction.service.ts
@@ -1,0 +1,56 @@
+{
+  ;`import { Injectable, Logger } from '@nestjs/common';
+// import * as Tesseract from 'tesseract.js'; // Uncomment and install if using Tesseract.js
+
+@Injectable()
+export class OcrExtractionService {
+  private readonly logger = new Logger(OcrExtractionService.name);
+
+  /**
+   * Extracts text from a given image/PDF URL using OCR.
+   * This method is initially mocked to simulate OCR processing.
+   * To integrate with a real OCR engine:
+   * 1. Install 'tesseract.js' (npm install tesseract.js) or integrate with a cloud OCR API (e.g., Google Cloud Vision, AWS Textract).
+   * 2. Uncomment the Tesseract import.
+   * 3. Replace the mock implementation with actual OCR logic.
+   * @param documentUrl The URL of the image or PDF file.
+   * @returns A Promise that resolves to the extracted text string.
+   */
+  async extractText(documentUrl: string): Promise<string> {
+    this.logger.log(\`Simulating OCR extraction for: \${documentUrl}\`);
+
+    // Simulate network delay and processing time
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    // --- MOCK IMPLEMENTATION ---
+    // Replace this with actual OCR integration.
+    /*
+    // Example with Tesseract.js (requires installation and potentially language data):
+    try {
+      const { data: { text } } = await Tesseract.recognize(
+        documentUrl,
+        'eng', // Specify language, e.g., 'eng' for English
+        { logger: m => this.logger.debug(m.status + ' ' + m.progress) }
+      );
+      this.logger.log(\`OCR completed for \${documentUrl}\`);
+      return text;
+    } catch (error) {
+      this.logger.error(\`OCR failed for \${documentUrl}: \${error.message}\`);
+      // Depending on requirements, you might throw, return empty string, or a specific error object
+      return '';
+    }
+    */
+
+    // Mocked response based on URL content for demonstration
+    if (documentUrl.includes('land-deed')) {
+      return \`Extracted text from land deed: This document certifies the transfer of property located at 123 Main St. from John Doe to Jane Smith. Dated: 2023-01-15. Parcel ID: ABC-123. Legal Description: Lot 1, Block 2, Subdivision of Green Valley.\`;
+    } else if (documentUrl.includes('survey-plan')) {
+      return \`Extracted text from survey plan: Lot 42, Block B. Area: 1500 sq meters. Coordinates: (X: 100, Y: 200). Surveyed by: ABC Surveyors. Date of Survey: 2022-11-01. Bearing: N 45° E.\`;
+    } else if (documentUrl.includes('court-order')) {
+      return \`Extracted text from court order: Case No. 2023-CV-001. Plaintiff: Alice Brown. Defendant: Bob White. Order: The court rules in favor of the plaintiff, granting full ownership rights to the disputed land parcel. Effective Date: 2023-07-20.\`;
+    } else {
+      return \`Extracted text from generic document: This is some sample text extracted from \${documentUrl}. It contains various details relevant to the document's content, including potential clauses and agreements. This text can be used for further AI analysis in SMALDA.\`;
+    }
+  }
+}`
+}

--- a/backend/src/ocr-extraction/ocr-extraction.spec.ts
+++ b/backend/src/ocr-extraction/ocr-extraction.spec.ts
@@ -1,0 +1,94 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { OcrExtractionService } from "./ocr-extraction.service"
+import { OcrExtractionController } from "./ocr-extraction.controller"
+import type { OcrRequestDto, OcrResponseDto } from "./dto/ocr-extraction.dto"
+
+describe("OcrExtractionService", () => {
+  let service: OcrExtractionService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OcrExtractionService],
+    }).compile()
+
+    service = module.get<OcrExtractionService>(OcrExtractionService)
+    jest.spyOn(service as any, "logger").mockImplementation(() => ({
+      log: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    }))
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  it("should return mocked text for a land-deed URL", async () => {
+    const documentUrl = "http://example.com/documents/land-deed-123.pdf"
+    const expectedText =
+      "Extracted text from land deed: This document certifies the transfer of property located at 123 Main St. from John Doe to Jane Smith. Dated: 2023-01-15. Parcel ID: ABC-123. Legal Description: Lot 1, Block 2, Subdivision of Green Valley."
+    const result = await service.extractText(documentUrl)
+    expect(result).toBe(expectedText)
+  })
+
+  it("should return mocked text for a survey-plan URL", async () => {
+    const documentUrl = "http://example.com/documents/survey-plan-xyz.jpg"
+    const expectedText =
+      "Extracted text from survey plan: Lot 42, Block B. Area: 1500 sq meters. Coordinates: (X: 100, Y: 200). Surveyed by: ABC Surveyors. Date of Survey: 2022-11-01. Bearing: N 45° E."
+    const result = await service.extractText(documentUrl)
+    expect(result).toBe(expectedText)
+  })
+
+  it("should return mocked text for a court-order URL", async () => {
+    const documentUrl = "http://example.com/documents/court-order-001.png"
+    const expectedText =
+      "Extracted text from court order: Case No. 2023-CV-001. Plaintiff: Alice Brown. Defendant: Bob White. Order: The court rules in favor of the plaintiff, granting full ownership rights to the disputed land parcel. Effective Date: 2023-07-20."
+    const result = await service.extractText(documentUrl)
+    expect(result).toBe(expectedText)
+  })
+
+  it("should return generic mocked text for an unknown URL", async () => {
+    const documentUrl = "http://example.com/documents/unknown-doc.pdf"
+    const expectedText = `Extracted text from generic document: This is some sample text extracted from ${documentUrl}. It contains various details relevant to the document's content, including potential clauses and agreements. This text can be used for further AI analysis in SMALDA.`
+    const result = await service.extractText(documentUrl)
+    expect(result).toBe(expectedText)
+  })
+})
+
+describe("OcrExtractionController", () => {
+  let controller: OcrExtractionController
+  let service: OcrExtractionService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OcrExtractionController],
+      providers: [
+        {
+          provide: OcrExtractionService,
+          useValue: {
+            extractText: jest.fn(),
+          },
+        },
+      ],
+    }).compile()
+
+    controller = module.get<OcrExtractionController>(OcrExtractionController)
+    service = module.get<OcrExtractionService>(OcrExtractionService)
+  })
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined()
+  })
+
+  it("should call OcrExtractionService.extractText and return the result", async () => {
+    const ocrRequest: OcrRequestDto = { documentUrl: "http://test.com/doc.pdf" }
+    const extractedText = "Mocked extracted text."
+    const expectedResponse: OcrResponseDto = { extractedText }
+
+    jest.spyOn(service, "extractText").mockResolvedValue(extractedText)
+
+    const result = await controller.extractText(ocrRequest)
+    expect(service.extractText).toHaveBeenCalledWith(ocrRequest.documentUrl)
+    expect(result).toEqual(expectedResponse)
+  })
+})


### PR DESCRIPTION
This PR sets up the foundational structure for the `ocr-extraction` module in the Smalda backend project. Key additions and changes include:

* Created `ocr-extraction` module, controller, and service files using NestJS CLI.
* Added placeholder methods for future OCR extraction logic.
* Registered the module in the main app module for integration.
* Prepared structure for future integration with OCR libraries (e.g., Tesseract or Google Vision API).

This setup lays the groundwork for future OCR-based document analysis and risk detection in land ownership documents.

closes #69 