### PR TITLE
property owner feature

### DIFF
--- a/backend/src/property-owner/dto/create-property-owner.dto.ts
+++ b/backend/src/property-owner/dto/create-property-owner.dto.ts
@@ -1,0 +1,148 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsEnum,
+  IsEmail,
+  IsDateString,
+  IsBoolean,
+  IsObject,
+  ValidateIf,
+  MaxLength,
+} from "class-validator"
+import { OwnerType } from "../enums/owner-type.enum"
+import { CorporateType } from "../enums/corporate-type.enum"
+import { ApiProperty } from "@nestjs/swagger"
+
+export class CreatePropertyOwnerDto {
+  @ApiProperty({ enum: OwnerType, description: "Type of owner (individual or corporate)" })
+  @IsNotEmpty()
+  @IsEnum(OwnerType)
+  ownerType: OwnerType
+
+  // Individual-specific fields (required when ownerType is INDIVIDUAL)
+  @ApiProperty({ description: "First name (required for individuals)", required: false })
+  @ValidateIf((o) => o.ownerType === OwnerType.INDIVIDUAL)
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(100)
+  firstName?: string
+
+  @ApiProperty({ description: "Last name (required for individuals)", required: false })
+  @ValidateIf((o) => o.ownerType === OwnerType.INDIVIDUAL)
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(100)
+  lastName?: string
+
+  @ApiProperty({ description: "Date of birth (for individuals)", required: false, format: "date" })
+  @IsOptional()
+  @IsDateString()
+  dateOfBirth?: string
+
+  @ApiProperty({ description: "National ID or passport number (for individuals)", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  nationalId?: string
+
+  // Corporate-specific fields (required when ownerType is CORPORATE)
+  @ApiProperty({ description: "Company/organization name (required for corporates)", required: false })
+  @ValidateIf((o) => o.ownerType === OwnerType.CORPORATE)
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(255)
+  companyName?: string
+
+  @ApiProperty({ description: "Registration number (for corporates)", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  registrationNumber?: string
+
+  @ApiProperty({ enum: CorporateType, description: "Type of corporate entity", required: false })
+  @IsOptional()
+  @IsEnum(CorporateType)
+  corporateType?: CorporateType
+
+  @ApiProperty({ description: "Date of incorporation/establishment (for corporates)", required: false, format: "date" })
+  @IsOptional()
+  @IsDateString()
+  incorporationDate?: string
+
+  @ApiProperty({ description: "Tax identification number", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  taxId?: string
+
+  // Common contact information
+  @ApiProperty({ description: "Primary email address" })
+  @IsNotEmpty()
+  @IsEmail()
+  @MaxLength(255)
+  email: string
+
+  @ApiProperty({ description: "Primary phone number", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  phoneNumber?: string
+
+  @ApiProperty({ description: "Secondary phone number", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  alternatePhoneNumber?: string
+
+  // Address information
+  @ApiProperty({ description: "Street address" })
+  @IsNotEmpty()
+  @IsString()
+  address: string
+
+  @ApiProperty({ description: "City", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  city?: string
+
+  @ApiProperty({ description: "State/Province", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  state?: string
+
+  @ApiProperty({ description: "Postal/ZIP code", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  postalCode?: string
+
+  @ApiProperty({ description: "Country", default: "Nigeria" })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  country?: string
+
+  // Additional information
+  @ApiProperty({ description: "Additional notes or comments about the owner", required: false })
+  @IsOptional()
+  @IsString()
+  notes?: string
+
+  @ApiProperty({ description: "Whether the owner is currently active", required: false, default: true })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean
+
+  @ApiProperty({
+    description: "Additional metadata",
+    type: "object",
+    additionalProperties: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/backend/src/property-owner/dto/filter-property-owner.dto.ts
+++ b/backend/src/property-owner/dto/filter-property-owner.dto.ts
@@ -1,0 +1,90 @@
+import { IsOptional, IsEnum, IsString, IsNumber, Min, Max, IsBoolean } from "class-validator"
+import { Type, Transform } from "class-transformer"
+import { OwnerType } from "../enums/owner-type.enum"
+import { CorporateType } from "../enums/corporate-type.enum"
+import { ApiProperty } from "@nestjs/swagger"
+
+export class FilterPropertyOwnerDto {
+  @ApiProperty({ enum: OwnerType, description: "Filter by owner type", required: false })
+  @IsOptional()
+  @IsEnum(OwnerType)
+  ownerType?: OwnerType
+
+  @ApiProperty({ description: "Search term for name (works for both individual and corporate names)", required: false })
+  @IsOptional()
+  @IsString()
+  search?: string
+
+  @ApiProperty({ description: "Filter by email address (partial match)", required: false })
+  @IsOptional()
+  @IsString()
+  email?: string
+
+  @ApiProperty({ description: "Filter by phone number (partial match)", required: false })
+  @IsOptional()
+  @IsString()
+  phoneNumber?: string
+
+  @ApiProperty({ description: "Filter by city", required: false })
+  @IsOptional()
+  @IsString()
+  city?: string
+
+  @ApiProperty({ description: "Filter by state/province", required: false })
+  @IsOptional()
+  @IsString()
+  state?: string
+
+  @ApiProperty({ description: "Filter by country", required: false })
+  @IsOptional()
+  @IsString()
+  country?: string
+
+  @ApiProperty({
+    enum: CorporateType,
+    description: "Filter by corporate type (only for corporate owners)",
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(CorporateType)
+  corporateType?: CorporateType
+
+  @ApiProperty({ description: "Filter by active status", required: false })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === "true") return true
+    if (value === "false") return false
+    return value
+  })
+  @IsBoolean()
+  isActive?: boolean
+
+  @ApiProperty({ description: "Page number for pagination", required: false, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number
+
+  @ApiProperty({ description: "Number of items per page", required: false, default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number
+
+  @ApiProperty({
+    description: "Field to sort by (e.g., createdAt, firstName, companyName)",
+    required: false,
+    default: "createdAt",
+  })
+  @IsOptional()
+  @IsString()
+  sortBy?: string
+
+  @ApiProperty({ enum: ["ASC", "DESC"], description: "Sort order (ASC or DESC)", required: false, default: "DESC" })
+  @IsOptional()
+  @IsEnum(["ASC", "DESC"])
+  sortOrder?: "ASC" | "DESC"
+}

--- a/backend/src/property-owner/dto/update-property-owner.dto.ts
+++ b/backend/src/property-owner/dto/update-property-owner.dto.ts
@@ -1,0 +1,136 @@
+import { PartialType } from "@nestjs/swagger"
+import { CreatePropertyOwnerDto } from "./create-property-owner.dto"
+import { IsString, IsOptional, IsEnum, IsEmail, IsDateString, IsBoolean, IsObject, MaxLength } from "class-validator"
+import { OwnerType } from "../enums/owner-type.enum"
+import { CorporateType } from "../enums/corporate-type.enum"
+import { ApiProperty } from "@nestjs/swagger"
+
+export class UpdatePropertyOwnerDto extends PartialType(CreatePropertyOwnerDto) {
+  @ApiProperty({ enum: OwnerType, description: "Type of owner (individual or corporate)", required: false })
+  @IsOptional()
+  @IsEnum(OwnerType)
+  ownerType?: OwnerType
+
+  // Individual-specific fields
+  @ApiProperty({ description: "First name", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  firstName?: string
+
+  @ApiProperty({ description: "Last name", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  lastName?: string
+
+  @ApiProperty({ description: "Date of birth", required: false, format: "date" })
+  @IsOptional()
+  @IsDateString()
+  dateOfBirth?: string
+
+  @ApiProperty({ description: "National ID or passport number", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  nationalId?: string
+
+  // Corporate-specific fields
+  @ApiProperty({ description: "Company/organization name", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  companyName?: string
+
+  @ApiProperty({ description: "Registration number", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  registrationNumber?: string
+
+  @ApiProperty({ enum: CorporateType, description: "Type of corporate entity", required: false })
+  @IsOptional()
+  @IsEnum(CorporateType)
+  corporateType?: CorporateType
+
+  @ApiProperty({ description: "Date of incorporation/establishment", required: false, format: "date" })
+  @IsOptional()
+  @IsDateString()
+  incorporationDate?: string
+
+  @ApiProperty({ description: "Tax identification number", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  taxId?: string
+
+  // Common contact information
+  @ApiProperty({ description: "Primary email address", required: false })
+  @IsOptional()
+  @IsEmail()
+  @MaxLength(255)
+  email?: string
+
+  @ApiProperty({ description: "Primary phone number", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  phoneNumber?: string
+
+  @ApiProperty({ description: "Secondary phone number", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  alternatePhoneNumber?: string
+
+  // Address information
+  @ApiProperty({ description: "Street address", required: false })
+  @IsOptional()
+  @IsString()
+  address?: string
+
+  @ApiProperty({ description: "City", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  city?: string
+
+  @ApiProperty({ description: "State/Province", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  state?: string
+
+  @ApiProperty({ description: "Postal/ZIP code", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  postalCode?: string
+
+  @ApiProperty({ description: "Country", required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  country?: string
+
+  // Additional information
+  @ApiProperty({ description: "Additional notes or comments about the owner", required: false })
+  @IsOptional()
+  @IsString()
+  notes?: string
+
+  @ApiProperty({ description: "Whether the owner is currently active", required: false })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean
+
+  @ApiProperty({
+    description: "Additional metadata",
+    type: "object",
+    additionalProperties: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+}

--- a/backend/src/property-owner/entities/property-owner.entity.ts
+++ b/backend/src/property-owner/entities/property-owner.entity.ts
@@ -1,0 +1,133 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+  OneToMany,
+} from "typeorm"
+import { OwnerType } from "../enums/owner-type.enum"
+import { CorporateType } from "../enums/corporate-type.enum"
+import { Document } from "../../document-history/entities/document.entity"
+import { ApiProperty } from "@nestjs/swagger"
+
+@Entity("property_owners")
+export class PropertyOwner {
+  @ApiProperty({ description: "Unique identifier for the property owner" })
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @ApiProperty({ enum: OwnerType, description: "Type of owner (individual or corporate)" })
+  @Column({ type: "enum", enum: OwnerType })
+  ownerType: OwnerType
+
+  // Individual-specific fields
+  @ApiProperty({ description: "First name (for individuals)", nullable: true })
+  @Column({ type: "varchar", length: 100, nullable: true })
+  firstName?: string
+
+  @ApiProperty({ description: "Last name (for individuals)", nullable: true })
+  @Column({ type: "varchar", length: 100, nullable: true })
+  lastName?: string
+
+  @ApiProperty({ description: "Date of birth (for individuals)", nullable: true })
+  @Column({ type: "date", nullable: true })
+  dateOfBirth?: Date
+
+  @ApiProperty({ description: "National ID or passport number (for individuals)", nullable: true })
+  @Column({ type: "varchar", length: 50, nullable: true })
+  nationalId?: string
+
+  // Corporate-specific fields
+  @ApiProperty({ description: "Company/organization name (for corporates)", nullable: true })
+  @Column({ type: "varchar", length: 255, nullable: true })
+  companyName?: string
+
+  @ApiProperty({ description: "Registration number (for corporates)", nullable: true })
+  @Column({ type: "varchar", length: 100, nullable: true })
+  registrationNumber?: string
+
+  @ApiProperty({ enum: CorporateType, description: "Type of corporate entity", nullable: true })
+  @Column({ type: "enum", enum: CorporateType, nullable: true })
+  corporateType?: CorporateType
+
+  @ApiProperty({ description: "Date of incorporation/establishment (for corporates)", nullable: true })
+  @Column({ type: "date", nullable: true })
+  incorporationDate?: Date
+
+  @ApiProperty({ description: "Tax identification number", nullable: true })
+  @Column({ type: "varchar", length: 50, nullable: true })
+  taxId?: string
+
+  // Common contact information
+  @ApiProperty({ description: "Primary email address" })
+  @Column({ type: "varchar", length: 255 })
+  email: string
+
+  @ApiProperty({ description: "Primary phone number", nullable: true })
+  @Column({ type: "varchar", length: 20, nullable: true })
+  phoneNumber?: string
+
+  @ApiProperty({ description: "Secondary phone number", nullable: true })
+  @Column({ type: "varchar", length: 20, nullable: true })
+  alternatePhoneNumber?: string
+
+  // Address information
+  @ApiProperty({ description: "Street address" })
+  @Column({ type: "text" })
+  address: string
+
+  @ApiProperty({ description: "City", nullable: true })
+  @Column({ type: "varchar", length: 100, nullable: true })
+  city?: string
+
+  @ApiProperty({ description: "State/Province", nullable: true })
+  @Column({ type: "varchar", length: 100, nullable: true })
+  state?: string
+
+  @ApiProperty({ description: "Postal/ZIP code", nullable: true })
+  @Column({ type: "varchar", length: 20, nullable: true })
+  postalCode?: string
+
+  @ApiProperty({ description: "Country" })
+  @Column({ type: "varchar", length: 100, default: "Nigeria" })
+  country: string
+
+  // Additional information
+  @ApiProperty({ description: "Additional notes or comments about the owner", nullable: true })
+  @Column({ type: "text", nullable: true })
+  notes?: string
+
+  @ApiProperty({ description: "Whether the owner is currently active", default: true })
+  @Column({ type: "boolean", default: true })
+  isActive: boolean
+
+  @ApiProperty({
+    description: "Additional metadata (e.g., legal representative info, emergency contacts)",
+    type: "object",
+    additionalProperties: true,
+    nullable: true,
+  })
+  @Column({ type: "jsonb", nullable: true })
+  metadata?: Record<string, any>
+
+  @ApiProperty({ type: () => [Document], description: "Documents owned by this property owner" })
+  @OneToMany(
+    () => Document,
+    (document) => document.owner,
+  )
+  documents: Document[]
+
+  @ApiProperty({ description: "Timestamp when the property owner record was created" })
+  @CreateDateColumn({ type: "timestamp with time zone", default: () => "CURRENT_TIMESTAMP" })
+  createdAt: Date
+
+  @ApiProperty({ description: "Timestamp when the property owner record was last updated" })
+  @UpdateDateColumn({ type: "timestamp with time zone", default: () => "CURRENT_TIMESTAMP" })
+  updatedAt: Date
+
+  @ApiProperty({ description: "Timestamp when the property owner record was soft-deleted", nullable: true })
+  @DeleteDateColumn({ type: "timestamp with time zone", nullable: true })
+  deletedAt?: Date
+}

--- a/backend/src/property-owner/enums/corporate-type.enum.ts
+++ b/backend/src/property-owner/enums/corporate-type.enum.ts
@@ -1,0 +1,8 @@
+export enum CorporateType {
+  COMPANY = "company",
+  PARTNERSHIP = "partnership",
+  TRUST = "trust",
+  GOVERNMENT = "government",
+  NGO = "ngo",
+  OTHER = "other",
+}

--- a/backend/src/property-owner/enums/owner-type.enum.ts
+++ b/backend/src/property-owner/enums/owner-type.enum.ts
@@ -1,0 +1,4 @@
+export enum OwnerType {
+  INDIVIDUAL = "individual",
+  CORPORATE = "corporate",
+}

--- a/backend/src/property-owner/property-owner.controller.ts
+++ b/backend/src/property-owner/property-owner.controller.ts
@@ -1,0 +1,154 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Delete,
+  Body,
+  Query,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  ConflictException,
+} from "@nestjs/common"
+import type { PropertyOwnerService } from "./property-owner.service"
+import type { CreatePropertyOwnerDto } from "./dto/create-property-owner.dto"
+import type { UpdatePropertyOwnerDto } from "./dto/update-property-owner.dto"
+import type { FilterPropertyOwnerDto } from "./dto/filter-property-owner.dto"
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from "@nestjs/swagger"
+import { PropertyOwner } from "./entities/property-owner.entity"
+import { OwnerType } from "./enums/owner-type.enum"
+import { CorporateType } from "./enums/corporate-type.enum"
+
+@ApiTags("Property Owners")
+@Controller("property-owners")
+export class PropertyOwnerController {
+  constructor(private readonly propertyOwnerService: PropertyOwnerService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: "Create a new property owner" })
+  @ApiResponse({ status: HttpStatus.CREATED, description: "Property owner successfully created.", type: PropertyOwner })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: "Invalid input data." })
+  @ApiResponse({ status: HttpStatus.CONFLICT, description: "Property owner with this email already exists." })
+  async create(@Body() createPropertyOwnerDto: CreatePropertyOwnerDto) {
+    try {
+      return await this.propertyOwnerService.create(createPropertyOwnerDto)
+    } catch (error) {
+      if (error instanceof ConflictException) {
+        throw new ConflictException(error.message)
+      }
+      throw error
+    }
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Retrieve all property owners with optional filtering and pagination" })
+  @ApiResponse({ status: HttpStatus.OK, description: "List of property owners.", type: [PropertyOwner] })
+  @ApiQuery({ name: "ownerType", required: false, enum: OwnerType, description: "Filter by owner type" })
+  @ApiQuery({ name: "search", required: false, type: String, description: "Search term for name" })
+  @ApiQuery({ name: "email", required: false, type: String, description: "Filter by email address" })
+  @ApiQuery({ name: "phoneNumber", required: false, type: String, description: "Filter by phone number" })
+  @ApiQuery({ name: "city", required: false, type: String, description: "Filter by city" })
+  @ApiQuery({ name: "state", required: false, type: String, description: "Filter by state/province" })
+  @ApiQuery({ name: "country", required: false, type: String, description: "Filter by country" })
+  @ApiQuery({ name: "corporateType", required: false, enum: CorporateType, description: "Filter by corporate type" })
+  @ApiQuery({ name: "isActive", required: false, type: Boolean, description: "Filter by active status" })
+  @ApiQuery({ name: "page", required: false, type: Number, description: "Page number for pagination" })
+  @ApiQuery({ name: "limit", required: false, type: Number, description: "Number of items per page" })
+  @ApiQuery({ name: "sortBy", required: false, type: String, description: "Field to sort by" })
+  @ApiQuery({ name: "sortOrder", required: false, enum: ["ASC", "DESC"], description: "Sort order" })
+  async findAll(@Query() filterPropertyOwnerDto: FilterPropertyOwnerDto) {
+    return this.propertyOwnerService.findAll(filterPropertyOwnerDto)
+  }
+
+  @Get("statistics")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Get property owner statistics" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Property owner statistics.",
+    schema: {
+      type: "object",
+      properties: {
+        total: { type: "number" },
+        individual: { type: "number" },
+        corporate: { type: "number" },
+        active: { type: "number" },
+        inactive: { type: "number" },
+      },
+    },
+  })
+  async getStatistics() {
+    return this.propertyOwnerService.getStatistics()
+  }
+
+  @Get("type/:ownerType")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Retrieve property owners by type" })
+  @ApiResponse({ status: HttpStatus.OK, description: "List of property owners by type.", type: [PropertyOwner] })
+  @ApiParam({ name: "ownerType", enum: OwnerType, description: "Type of owner to filter by" })
+  async findByType(@Param("ownerType") ownerType: OwnerType) {
+    return this.propertyOwnerService.findByType(ownerType)
+  }
+
+  @Get("active")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Retrieve all active property owners" })
+  @ApiResponse({ status: HttpStatus.OK, description: "List of active property owners.", type: [PropertyOwner] })
+  async findActive() {
+    return this.propertyOwnerService.findActive()
+  }
+
+  @Get(":id")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Retrieve a single property owner by ID" })
+  @ApiResponse({ status: HttpStatus.OK, description: "Property owner found.", type: PropertyOwner })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Property owner not found." })
+  @ApiParam({ name: "id", type: String, description: "UUID of the property owner" })
+  async findOne(@Param("id") id: string) {
+    const propertyOwner = await this.propertyOwnerService.findOne(id)
+    if (!propertyOwner) {
+      throw new NotFoundException(`Property owner with ID "${id}" not found.`)
+    }
+    return propertyOwner
+  }
+
+  @Patch(":id")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Update an existing property owner" })
+  @ApiResponse({ status: HttpStatus.OK, description: "Property owner successfully updated.", type: PropertyOwner })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Property owner not found." })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: "Invalid input data." })
+  @ApiResponse({ status: HttpStatus.CONFLICT, description: "Property owner with this email already exists." })
+  @ApiParam({ name: "id", type: String, description: "UUID of the property owner to update" })
+  async update(@Param("id") id: string, @Body() updatePropertyOwnerDto: UpdatePropertyOwnerDto) {
+    try {
+      const updatedPropertyOwner = await this.propertyOwnerService.update(id, updatePropertyOwnerDto)
+      if (!updatedPropertyOwner) {
+        throw new NotFoundException(`Property owner with ID "${id}" not found.`)
+      }
+      return updatedPropertyOwner
+    } catch (error) {
+      if (error instanceof ConflictException) {
+        throw new ConflictException(error.message)
+      }
+      throw error
+    }
+  }
+
+  @Delete(":id")
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: "Delete a property owner (soft delete)" })
+  @ApiResponse({ status: HttpStatus.NO_CONTENT, description: "Property owner successfully deleted." })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Property owner not found." })
+  @ApiParam({ name: "id", type: String, description: "UUID of the property owner to delete" })
+  async remove(@Param("id") id: string) {
+    const result = await this.propertyOwnerService.remove(id)
+    if (!result) {
+      throw new NotFoundException(`Property owner with ID "${id}" not found.`)
+    }
+  }
+}

--- a/backend/src/property-owner/property-owner.module.ts
+++ b/backend/src/property-owner/property-owner.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { PropertyOwnerService } from "./property-owner.service"
+import { PropertyOwnerController } from "./property-owner.controller"
+import { PropertyOwner } from "./entities/property-owner.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PropertyOwner])],
+  controllers: [PropertyOwnerController],
+  providers: [PropertyOwnerService],
+  exports: [PropertyOwnerService], // Export for use in other modules (e.g., DocumentHistory)
+})
+export class PropertyOwnerModule {}

--- a/backend/src/property-owner/property-owner.service.ts
+++ b/backend/src/property-owner/property-owner.service.ts
@@ -1,0 +1,222 @@
+import { Injectable, ConflictException } from "@nestjs/common"
+import { type Repository, IsNull } from "typeorm"
+import type { PropertyOwner } from "./entities/property-owner.entity"
+import type { CreatePropertyOwnerDto } from "./dto/create-property-owner.dto"
+import type { UpdatePropertyOwnerDto } from "./dto/update-property-owner.dto"
+import type { FilterPropertyOwnerDto } from "./dto/filter-property-owner.dto"
+import { OwnerType } from "./enums/owner-type.enum"
+
+@Injectable()
+export class PropertyOwnerService {
+  constructor(private propertyOwnerRepository: Repository<PropertyOwner>) {}
+
+  /**
+   * Creates a new property owner.
+   * @param createPropertyOwnerDto The DTO containing property owner data.
+   * @returns The created property owner entity.
+   * @throws ConflictException if an owner with the same email already exists.
+   */
+  async create(createPropertyOwnerDto: CreatePropertyOwnerDto): Promise<PropertyOwner> {
+    // Check for existing owner with same email
+    const existingOwner = await this.propertyOwnerRepository.findOne({
+      where: { email: createPropertyOwnerDto.email, deletedAt: IsNull() },
+    })
+    if (existingOwner) {
+      throw new ConflictException(`Property owner with email "${createPropertyOwnerDto.email}" already exists.`)
+    }
+
+    // Convert date strings to Date objects
+    const ownerData = {
+      ...createPropertyOwnerDto,
+      dateOfBirth: createPropertyOwnerDto.dateOfBirth ? new Date(createPropertyOwnerDto.dateOfBirth) : undefined,
+      incorporationDate: createPropertyOwnerDto.incorporationDate
+        ? new Date(createPropertyOwnerDto.incorporationDate)
+        : undefined,
+      country: createPropertyOwnerDto.country || "Nigeria",
+      isActive: createPropertyOwnerDto.isActive ?? true,
+    }
+
+    const propertyOwner = this.propertyOwnerRepository.create(ownerData)
+    return this.propertyOwnerRepository.save(propertyOwner)
+  }
+
+  /**
+   * Retrieves all property owners with optional filtering, pagination, and sorting.
+   * @param filterDto The DTO containing filter, pagination, and sort parameters.
+   * @returns An object containing property owners and total count.
+   */
+  async findAll(filterDto: FilterPropertyOwnerDto): Promise<{ data: PropertyOwner[]; total: number }> {
+    const {
+      ownerType,
+      search,
+      email,
+      phoneNumber,
+      city,
+      state,
+      country,
+      corporateType,
+      isActive,
+      page = 1,
+      limit = 10,
+      sortBy = "createdAt",
+      sortOrder = "DESC",
+    } = filterDto
+
+    const queryBuilder = this.propertyOwnerRepository.createQueryBuilder("owner")
+    queryBuilder.where("owner.deletedAt IS NULL")
+
+    // Apply filters
+    if (ownerType) {
+      queryBuilder.andWhere("owner.ownerType = :ownerType", { ownerType })
+    }
+    if (search) {
+      queryBuilder.andWhere(
+        "(owner.firstName ILIKE :search OR owner.lastName ILIKE :search OR owner.companyName ILIKE :search)",
+        { search: `%${search}%` },
+      )
+    }
+    if (email) {
+      queryBuilder.andWhere("owner.email ILIKE :email", { email: `%${email}%` })
+    }
+    if (phoneNumber) {
+      queryBuilder.andWhere("(owner.phoneNumber ILIKE :phoneNumber OR owner.alternatePhoneNumber ILIKE :phoneNumber)", {
+        phoneNumber: `%${phoneNumber}%`,
+      })
+    }
+    if (city) {
+      queryBuilder.andWhere("owner.city ILIKE :city", { city: `%${city}%` })
+    }
+    if (state) {
+      queryBuilder.andWhere("owner.state ILIKE :state", { state: `%${state}%` })
+    }
+    if (country) {
+      queryBuilder.andWhere("owner.country ILIKE :country", { country: `%${country}%` })
+    }
+    if (corporateType) {
+      queryBuilder.andWhere("owner.corporateType = :corporateType", { corporateType })
+    }
+    if (isActive !== undefined) {
+      queryBuilder.andWhere("owner.isActive = :isActive", { isActive })
+    }
+
+    queryBuilder.orderBy(`owner.${sortBy}`, sortOrder)
+    queryBuilder.skip((page - 1) * limit).take(limit)
+
+    const [data, total] = await queryBuilder.getManyAndCount()
+    return { data, total }
+  }
+
+  /**
+   * Retrieves a single property owner by its ID.
+   * @param id The UUID of the property owner.
+   * @returns The property owner entity or undefined if not found.
+   */
+  async findOne(id: string): Promise<PropertyOwner | undefined> {
+    return this.propertyOwnerRepository.findOne({
+      where: { id, deletedAt: IsNull() },
+      relations: ["documents"], // Eager load associated documents
+    })
+  }
+
+  /**
+   * Retrieves a property owner by email address.
+   * @param email The email address of the property owner.
+   * @returns The property owner entity or undefined if not found.
+   */
+  async findByEmail(email: string): Promise<PropertyOwner | undefined> {
+    return this.propertyOwnerRepository.findOne({
+      where: { email, deletedAt: IsNull() },
+    })
+  }
+
+  /**
+   * Updates an existing property owner.
+   * @param id The UUID of the property owner.
+   * @param updatePropertyOwnerDto The DTO containing updated property owner data.
+   * @returns The updated property owner entity or undefined if not found.
+   * @throws ConflictException if the new email already exists for another owner.
+   */
+  async update(id: string, updatePropertyOwnerDto: UpdatePropertyOwnerDto): Promise<PropertyOwner | undefined> {
+    const propertyOwner = await this.findOne(id)
+    if (!propertyOwner) {
+      return undefined
+    }
+
+    // Check for email conflict if email is being updated
+    if (updatePropertyOwnerDto.email && updatePropertyOwnerDto.email !== propertyOwner.email) {
+      const existingOwnerWithEmail = await this.propertyOwnerRepository.findOne({
+        where: { email: updatePropertyOwnerDto.email, deletedAt: IsNull() },
+      })
+      if (existingOwnerWithEmail && existingOwnerWithEmail.id !== id) {
+        throw new ConflictException(`Property owner with email "${updatePropertyOwnerDto.email}" already exists.`)
+      }
+    }
+
+    // Convert date strings to Date objects
+    const updateData = {
+      ...updatePropertyOwnerDto,
+      dateOfBirth: updatePropertyOwnerDto.dateOfBirth ? new Date(updatePropertyOwnerDto.dateOfBirth) : undefined,
+      incorporationDate: updatePropertyOwnerDto.incorporationDate
+        ? new Date(updatePropertyOwnerDto.incorporationDate)
+        : undefined,
+    }
+
+    Object.assign(propertyOwner, updateData)
+    return this.propertyOwnerRepository.save(propertyOwner)
+  }
+
+  /**
+   * Soft deletes a property owner.
+   * @param id The UUID of the property owner.
+   * @returns True if deleted, false if not found.
+   */
+  async remove(id: string): Promise<boolean> {
+    const result = await this.propertyOwnerRepository.softDelete(id)
+    return result.affected > 0
+  }
+
+  /**
+   * Retrieves property owners by type (individual or corporate).
+   * @param ownerType The type of owner to filter by.
+   * @returns An array of property owners of the specified type.
+   */
+  async findByType(ownerType: OwnerType): Promise<PropertyOwner[]> {
+    return this.propertyOwnerRepository.find({
+      where: { ownerType, deletedAt: IsNull() },
+      order: { createdAt: "DESC" },
+    })
+  }
+
+  /**
+   * Retrieves active property owners.
+   * @returns An array of active property owners.
+   */
+  async findActive(): Promise<PropertyOwner[]> {
+    return this.propertyOwnerRepository.find({
+      where: { isActive: true, deletedAt: IsNull() },
+      order: { createdAt: "DESC" },
+    })
+  }
+
+  /**
+   * Gets statistics about property owners.
+   * @returns An object containing various statistics.
+   */
+  async getStatistics(): Promise<{
+    total: number
+    individual: number
+    corporate: number
+    active: number
+    inactive: number
+  }> {
+    const [total, individual, corporate, active, inactive] = await Promise.all([
+      this.propertyOwnerRepository.count({ where: { deletedAt: IsNull() } }),
+      this.propertyOwnerRepository.count({ where: { ownerType: OwnerType.INDIVIDUAL, deletedAt: IsNull() } }),
+      this.propertyOwnerRepository.count({ where: { ownerType: OwnerType.CORPORATE, deletedAt: IsNull() } }),
+      this.propertyOwnerRepository.count({ where: { isActive: true, deletedAt: IsNull() } }),
+      this.propertyOwnerRepository.count({ where: { isActive: false, deletedAt: IsNull() } }),
+    ])
+
+    return { total, individual, corporate, active, inactive }
+  }
+}

--- a/backend/src/property-owner/property-owner.spec.ts
+++ b/backend/src/property-owner/property-owner.spec.ts
@@ -1,0 +1,506 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { PropertyOwnerService } from "./property-owner.service"
+import { PropertyOwnerController } from "./property-owner.controller"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { PropertyOwner } from "./entities/property-owner.entity"
+import type { Repository } from "typeorm"
+import type { CreatePropertyOwnerDto } from "./dto/create-property-owner.dto"
+import type { UpdatePropertyOwnerDto } from "./dto/update-property-owner.dto"
+import type { FilterPropertyOwnerDto } from "./dto/filter-property-owner.dto"
+import { OwnerType } from "./enums/owner-type.enum"
+import { CorporateType } from "./enums/corporate-type.enum"
+import { ConflictException, NotFoundException } from "@nestjs/common"
+import { jest } from "@jest/globals"
+
+// Mock Repository
+const mockPropertyOwnerRepository = {
+  create: jest.fn(),
+  save: jest.fn(),
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
+  softDelete: jest.fn(),
+  createQueryBuilder: jest.fn(() => ({
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn(),
+  })),
+}
+
+describe("PropertyOwnerService", () => {
+  let service: PropertyOwnerService
+  let propertyOwnerRepository: Repository<PropertyOwner>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PropertyOwnerService,
+        {
+          provide: getRepositoryToken(PropertyOwner),
+          useValue: mockPropertyOwnerRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<PropertyOwnerService>(PropertyOwnerService)
+    propertyOwnerRepository = module.get<Repository<PropertyOwner>>(getRepositoryToken(PropertyOwner))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  describe("create", () => {
+    it("should create and save a new individual property owner", async () => {
+      const createDto: CreatePropertyOwnerDto = {
+        ownerType: OwnerType.INDIVIDUAL,
+        firstName: "John",
+        lastName: "Doe",
+        email: "john.doe@example.com",
+        address: "123 Main St",
+        dateOfBirth: "1990-01-01",
+      }
+      const expectedOwner = {
+        id: "owner-1",
+        ...createDto,
+        dateOfBirth: new Date("1990-01-01"),
+        country: "Nigeria",
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockPropertyOwnerRepository.findOne.mockResolvedValue(undefined)
+      mockPropertyOwnerRepository.create.mockReturnValue(expectedOwner)
+      mockPropertyOwnerRepository.save.mockResolvedValue(expectedOwner)
+
+      const result = await service.create(createDto)
+      expect(mockPropertyOwnerRepository.findOne).toHaveBeenCalledWith({
+        where: { email: createDto.email, deletedAt: null },
+      })
+      expect(mockPropertyOwnerRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...createDto,
+          dateOfBirth: new Date("1990-01-01"),
+          country: "Nigeria",
+          isActive: true,
+        }),
+      )
+      expect(mockPropertyOwnerRepository.save).toHaveBeenCalledWith(expectedOwner)
+      expect(result).toEqual(expectedOwner)
+    })
+
+    it("should create and save a new corporate property owner", async () => {
+      const createDto: CreatePropertyOwnerDto = {
+        ownerType: OwnerType.CORPORATE,
+        companyName: "Acme Corp",
+        email: "contact@acme.com",
+        address: "456 Business Ave",
+        corporateType: CorporateType.COMPANY,
+        registrationNumber: "RC123456",
+        incorporationDate: "2020-01-01",
+      }
+      const expectedOwner = {
+        id: "owner-2",
+        ...createDto,
+        incorporationDate: new Date("2020-01-01"),
+        country: "Nigeria",
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockPropertyOwnerRepository.findOne.mockResolvedValue(undefined)
+      mockPropertyOwnerRepository.create.mockReturnValue(expectedOwner)
+      mockPropertyOwnerRepository.save.mockResolvedValue(expectedOwner)
+
+      const result = await service.create(createDto)
+      expect(mockPropertyOwnerRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...createDto,
+          incorporationDate: new Date("2020-01-01"),
+          country: "Nigeria",
+          isActive: true,
+        }),
+      )
+      expect(result).toEqual(expectedOwner)
+    })
+
+    it("should throw ConflictException if email already exists", async () => {
+      const createDto: CreatePropertyOwnerDto = {
+        ownerType: OwnerType.INDIVIDUAL,
+        firstName: "Jane",
+        lastName: "Smith",
+        email: "existing@example.com",
+        address: "789 Oak St",
+      }
+      mockPropertyOwnerRepository.findOne.mockResolvedValue({ id: "existing-owner", email: "existing@example.com" })
+
+      await expect(service.create(createDto)).rejects.toThrow(ConflictException)
+      expect(mockPropertyOwnerRepository.create).not.toHaveBeenCalled()
+      expect(mockPropertyOwnerRepository.save).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("findAll", () => {
+    it("should return all property owners with pagination and total count", async () => {
+      const ownerList = [{ id: "owner-1", firstName: "John", lastName: "Doe" }]
+      mockPropertyOwnerRepository.createQueryBuilder().getManyAndCount.mockResolvedValue([ownerList, 1])
+
+      const result = await service.findAll({})
+      expect(mockPropertyOwnerRepository.createQueryBuilder).toHaveBeenCalled()
+      expect(result).toEqual({ data: ownerList, total: 1 })
+    })
+
+    it("should apply filters and sorting", async () => {
+      const filterDto: FilterPropertyOwnerDto = {
+        ownerType: OwnerType.INDIVIDUAL,
+        search: "john",
+        city: "Lagos",
+        isActive: true,
+        sortBy: "firstName",
+        sortOrder: "ASC",
+        page: 2,
+        limit: 5,
+      }
+      const ownerList = [{ id: "owner-2", firstName: "John", city: "Lagos" }]
+      mockPropertyOwnerRepository.createQueryBuilder().getManyAndCount.mockResolvedValue([ownerList, 1])
+
+      const queryBuilderMock = mockPropertyOwnerRepository.createQueryBuilder()
+      const result = await service.findAll(filterDto)
+
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("owner.ownerType = :ownerType", {
+        ownerType: OwnerType.INDIVIDUAL,
+      })
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith(
+        "(owner.firstName ILIKE :search OR owner.lastName ILIKE :search OR owner.companyName ILIKE :search)",
+        { search: "%john%" },
+      )
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("owner.city ILIKE :city", { city: "%Lagos%" })
+      expect(queryBuilderMock.andWhere).toHaveBeenCalledWith("owner.isActive = :isActive", { isActive: true })
+      expect(queryBuilderMock.orderBy).toHaveBeenCalledWith("owner.firstName", "ASC")
+      expect(queryBuilderMock.skip).toHaveBeenCalledWith(5)
+      expect(queryBuilderMock.take).toHaveBeenCalledWith(5)
+      expect(result).toEqual({ data: ownerList, total: 1 })
+    })
+  })
+
+  describe("findOne", () => {
+    it("should return a property owner with documents if found", async () => {
+      const owner = { id: "owner-1", firstName: "John", documents: [] }
+      mockPropertyOwnerRepository.findOne.mockResolvedValue(owner)
+
+      const result = await service.findOne("owner-1")
+      expect(mockPropertyOwnerRepository.findOne).toHaveBeenCalledWith({
+        where: { id: "owner-1", deletedAt: null },
+        relations: ["documents"],
+      })
+      expect(result).toEqual(owner)
+    })
+
+    it("should return undefined if property owner not found", async () => {
+      mockPropertyOwnerRepository.findOne.mockResolvedValue(undefined)
+      const result = await service.findOne("non-existent-id")
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("findByEmail", () => {
+    it("should return a property owner if found by email", async () => {
+      const owner = { id: "owner-1", email: "test@example.com" }
+      mockPropertyOwnerRepository.findOne.mockResolvedValue(owner)
+
+      const result = await service.findByEmail("test@example.com")
+      expect(mockPropertyOwnerRepository.findOne).toHaveBeenCalledWith({
+        where: { email: "test@example.com", deletedAt: null },
+      })
+      expect(result).toEqual(owner)
+    })
+  })
+
+  describe("update", () => {
+    it("should update an existing property owner", async () => {
+      const existingOwner = {
+        id: "owner-1",
+        firstName: "John",
+        lastName: "Doe",
+        email: "john@example.com",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      const updateDto: UpdatePropertyOwnerDto = { firstName: "Johnny", city: "Lagos" }
+      const updatedOwner = { ...existingOwner, ...updateDto }
+
+      mockPropertyOwnerRepository.findOne.mockResolvedValue(existingOwner)
+      mockPropertyOwnerRepository.save.mockResolvedValue(updatedOwner)
+
+      const result = await service.update("owner-1", updateDto)
+      expect(mockPropertyOwnerRepository.findOne).toHaveBeenCalledWith({
+        where: { id: "owner-1", deletedAt: null },
+        relations: ["documents"],
+      })
+      expect(mockPropertyOwnerRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "owner-1",
+          firstName: "Johnny",
+          city: "Lagos",
+        }),
+      )
+      expect(result).toEqual(updatedOwner)
+    })
+
+    it("should return undefined if property owner not found for update", async () => {
+      mockPropertyOwnerRepository.findOne.mockResolvedValue(undefined)
+      const result = await service.update("non-existent-id", { firstName: "New Name" })
+      expect(result).toBeUndefined()
+    })
+
+    it("should throw ConflictException if new email already exists for another owner", async () => {
+      const existingOwner = { id: "owner-1", email: "john@example.com" }
+      const anotherOwner = { id: "owner-2", email: "jane@example.com" }
+      const updateDto: UpdatePropertyOwnerDto = { email: "jane@example.com" }
+
+      mockPropertyOwnerRepository.findOne
+        .mockResolvedValueOnce(existingOwner) // First call for findOne
+        .mockResolvedValueOnce(anotherOwner) // Second call for email conflict check
+
+      await expect(service.update("owner-1", updateDto)).rejects.toThrow(ConflictException)
+      expect(mockPropertyOwnerRepository.save).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("remove", () => {
+    it("should soft delete a property owner", async () => {
+      mockPropertyOwnerRepository.softDelete.mockResolvedValue({ affected: 1 })
+
+      const result = await service.remove("owner-1")
+      expect(mockPropertyOwnerRepository.softDelete).toHaveBeenCalledWith("owner-1")
+      expect(result).toBe(true)
+    })
+
+    it("should return false if property owner not found for deletion", async () => {
+      mockPropertyOwnerRepository.softDelete.mockResolvedValue({ affected: 0 })
+
+      const result = await service.remove("non-existent-id")
+      expect(result).toBe(false)
+    })
+  })
+
+  describe("findByType", () => {
+    it("should return property owners by type", async () => {
+      const individualOwners = [{ id: "owner-1", ownerType: OwnerType.INDIVIDUAL }]
+      mockPropertyOwnerRepository.find.mockResolvedValue(individualOwners)
+
+      const result = await service.findByType(OwnerType.INDIVIDUAL)
+      expect(mockPropertyOwnerRepository.find).toHaveBeenCalledWith({
+        where: { ownerType: OwnerType.INDIVIDUAL, deletedAt: null },
+        order: { createdAt: "DESC" },
+      })
+      expect(result).toEqual(individualOwners)
+    })
+  })
+
+  describe("findActive", () => {
+    it("should return active property owners", async () => {
+      const activeOwners = [{ id: "owner-1", isActive: true }]
+      mockPropertyOwnerRepository.find.mockResolvedValue(activeOwners)
+
+      const result = await service.findActive()
+      expect(mockPropertyOwnerRepository.find).toHaveBeenCalledWith({
+        where: { isActive: true, deletedAt: null },
+        order: { createdAt: "DESC" },
+      })
+      expect(result).toEqual(activeOwners)
+    })
+  })
+
+  describe("getStatistics", () => {
+    it("should return property owner statistics", async () => {
+      mockPropertyOwnerRepository.count
+        .mockResolvedValueOnce(100) // total
+        .mockResolvedValueOnce(60) // individual
+        .mockResolvedValueOnce(40) // corporate
+        .mockResolvedValueOnce(90) // active
+        .mockResolvedValueOnce(10) // inactive
+
+      const result = await service.getStatistics()
+      expect(result).toEqual({
+        total: 100,
+        individual: 60,
+        corporate: 40,
+        active: 90,
+        inactive: 10,
+      })
+    })
+  })
+})
+
+describe("PropertyOwnerController", () => {
+  let controller: PropertyOwnerController
+  let service: PropertyOwnerService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PropertyOwnerController],
+      providers: [
+        {
+          provide: PropertyOwnerService,
+          useValue: {
+            create: jest.fn(),
+            findAll: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+            findByType: jest.fn(),
+            findActive: jest.fn(),
+            getStatistics: jest.fn(),
+          },
+        },
+      ],
+    }).compile()
+
+    controller = module.get<PropertyOwnerController>(PropertyOwnerController)
+    service = module.get<PropertyOwnerService>(PropertyOwnerService)
+  })
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined()
+  })
+
+  describe("create", () => {
+    it("should call service.create and return the created property owner", async () => {
+      const createDto: CreatePropertyOwnerDto = {
+        ownerType: OwnerType.INDIVIDUAL,
+        firstName: "John",
+        lastName: "Doe",
+        email: "john@example.com",
+        address: "123 Main St",
+      }
+      const expectedOwner = { id: "owner-1", ...createDto }
+      jest.spyOn(service, "create").mockResolvedValue(expectedOwner as PropertyOwner)
+
+      const result = await controller.create(createDto)
+      expect(service.create).toHaveBeenCalledWith(createDto)
+      expect(result).toEqual(expectedOwner)
+    })
+
+    it("should throw ConflictException if service.create throws ConflictException", async () => {
+      const createDto: CreatePropertyOwnerDto = {
+        ownerType: OwnerType.INDIVIDUAL,
+        firstName: "John",
+        lastName: "Doe",
+        email: "existing@example.com",
+        address: "123 Main St",
+      }
+      jest.spyOn(service, "create").mockRejectedValue(new ConflictException("Email already exists."))
+
+      await expect(controller.create(createDto)).rejects.toThrow(ConflictException)
+    })
+  })
+
+  describe("findAll", () => {
+    it("should call service.findAll and return a list of property owners", async () => {
+      const filterDto: FilterPropertyOwnerDto = { page: 1, limit: 10 }
+      const ownerList = { data: [{ id: "owner-1", firstName: "John" }], total: 1 }
+      jest.spyOn(service, "findAll").mockResolvedValue(ownerList as any)
+
+      const result = await controller.findAll(filterDto)
+      expect(service.findAll).toHaveBeenCalledWith(filterDto)
+      expect(result).toEqual(ownerList)
+    })
+  })
+
+  describe("getStatistics", () => {
+    it("should call service.getStatistics and return statistics", async () => {
+      const stats = { total: 100, individual: 60, corporate: 40, active: 90, inactive: 10 }
+      jest.spyOn(service, "getStatistics").mockResolvedValue(stats)
+
+      const result = await controller.getStatistics()
+      expect(service.getStatistics).toHaveBeenCalled()
+      expect(result).toEqual(stats)
+    })
+  })
+
+  describe("findByType", () => {
+    it("should call service.findByType and return property owners by type", async () => {
+      const owners = [{ id: "owner-1", ownerType: OwnerType.INDIVIDUAL }]
+      jest.spyOn(service, "findByType").mockResolvedValue(owners as PropertyOwner[])
+
+      const result = await controller.findByType(OwnerType.INDIVIDUAL)
+      expect(service.findByType).toHaveBeenCalledWith(OwnerType.INDIVIDUAL)
+      expect(result).toEqual(owners)
+    })
+  })
+
+  describe("findActive", () => {
+    it("should call service.findActive and return active property owners", async () => {
+      const activeOwners = [{ id: "owner-1", isActive: true }]
+      jest.spyOn(service, "findActive").mockResolvedValue(activeOwners as PropertyOwner[])
+
+      const result = await controller.findActive()
+      expect(service.findActive).toHaveBeenCalled()
+      expect(result).toEqual(activeOwners)
+    })
+  })
+
+  describe("findOne", () => {
+    it("should call service.findOne and return a single property owner", async () => {
+      const owner = { id: "owner-1", firstName: "John" }
+      jest.spyOn(service, "findOne").mockResolvedValue(owner as PropertyOwner)
+
+      const result = await controller.findOne("owner-1")
+      expect(service.findOne).toHaveBeenCalledWith("owner-1")
+      expect(result).toEqual(owner)
+    })
+
+    it("should throw NotFoundException if property owner not found", async () => {
+      jest.spyOn(service, "findOne").mockResolvedValue(undefined)
+      await expect(controller.findOne("non-existent-id")).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe("update", () => {
+    it("should call service.update and return the updated property owner", async () => {
+      const updateDto: UpdatePropertyOwnerDto = { firstName: "Johnny" }
+      const updatedOwner = { id: "owner-1", firstName: "Johnny" }
+      jest.spyOn(service, "update").mockResolvedValue(updatedOwner as PropertyOwner)
+
+      const result = await controller.update("owner-1", updateDto)
+      expect(service.update).toHaveBeenCalledWith("owner-1", updateDto)
+      expect(result).toEqual(updatedOwner)
+    })
+
+    it("should throw NotFoundException if property owner not found for update", async () => {
+      jest.spyOn(service, "update").mockResolvedValue(undefined)
+      await expect(controller.update("non-existent-id", {})).rejects.toThrow(NotFoundException)
+    })
+
+    it("should throw ConflictException if service.update throws ConflictException", async () => {
+      const updateDto: UpdatePropertyOwnerDto = { email: "conflicting@example.com" }
+      jest.spyOn(service, "update").mockRejectedValue(new ConflictException("Email already exists."))
+
+      await expect(controller.update("owner-1", updateDto)).rejects.toThrow(ConflictException)
+    })
+  })
+
+  describe("remove", () => {
+    it("should call service.remove and return nothing on success", async () => {
+      jest.spyOn(service, "remove").mockResolvedValue(true)
+      const result = await controller.remove("owner-1")
+      expect(service.remove).toHaveBeenCalledWith("owner-1")
+      expect(result).toBeUndefined()
+    })
+
+    it("should throw NotFoundException if property owner not found for removal", async () => {
+      jest.spyOn(service, "remove").mockResolvedValue(false)
+      await expect(controller.remove("non-existent-id")).rejects.toThrow(NotFoundException)
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces the `property-owner` module as part of the Smalda backend architecture. It includes the foundational setup necessary to manage property owner records and associations with land ownership documents.

**Key additions:**

* `property-owner.module.ts`: Registers providers and controllers.
* `property-owner.controller.ts`: Defines route handlers for creating and retrieving property owner data.
* `property-owner.service.ts`: Handles business logic related to property owners.
* DTOs for create and update operations.
* Entity definition for `PropertyOwner`, mapped to the database via TypeORM.

**Notes:**

* Basic CRUD functionality scaffolded.
* Integration with PostgreSQL through TypeORM.
* Includes placeholder validations and response structure.

closes #71 
