### PR TITLE
 PR: Add Land Dispute Risk Scoring Service (POST /risk/evaluate)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,11 +1,13 @@
-import { Module } from '@nestjs/common';
+ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TimelineGeneratorModule } from './timeline/timeline.module';
+import { RiskModule } from './risk/risk.module';
 
 @Module({
   imports: [
     TimelineGeneratorModule,
+    RiskModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,10 @@
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
+ import { NestFactory } from '@nestjs/core';
+ import { AppModule } from './app.module';
+ import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/backend/src/risk/dto/evaluate-risk.dto.ts
+++ b/backend/src/risk/dto/evaluate-risk.dto.ts
@@ -1,0 +1,107 @@
+import { IsArray, IsBoolean, IsDateString, IsIn, IsNumber, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class PartyDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  @IsIn(['buyer', 'seller', 'witness', 'agent', 'lawyer', 'unknown'])
+  role: string;
+}
+
+export class CourtCaseDto {
+  @IsString()
+  @IsOptional()
+  caseType?: string;
+
+  @IsString()
+  @IsIn(['pending', 'active', 'closed', 'appealed'])
+  status: string;
+
+  @IsOptional()
+  @IsDateString()
+  filedAt?: string;
+
+  @IsOptional()
+  @IsString()
+  outcome?: string;
+}
+
+export class EncumbranceDto {
+  @IsString()
+  type: string; // lien, mortgage, caveat, easement, etc.
+
+  @IsOptional()
+  @IsString()
+  details?: string;
+}
+
+export class PropertyDto {
+  @IsOptional()
+  @IsString()
+  location?: string;
+
+  @IsOptional()
+  @IsNumber()
+  sizeSqm?: number;
+
+  @IsOptional()
+  @IsString()
+  titleStatus?: string; // clear, provisional, disputed
+
+  @IsOptional()
+  @IsBoolean()
+  surveyMismatch?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  overlappingClaims?: boolean;
+}
+
+export class HistoryDto {
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => Object)
+  transactions?: Array<Record<string, any>>;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => Object)
+  disputes?: Array<Record<string, any>>;
+}
+
+export class EvaluateRiskDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PartyDto)
+  parties: PartyDto[];
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CourtCaseDto)
+  courtCases?: CourtCaseDto[];
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => EncumbranceDto)
+  encumbrances?: EncumbranceDto[];
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PropertyDto)
+  property?: PropertyDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => HistoryDto)
+  history?: HistoryDto;
+
+  @IsOptional()
+  @IsObject()
+  extra?: Record<string, any>;
+}

--- a/backend/src/risk/dto/risk-response.dto.ts
+++ b/backend/src/risk/dto/risk-response.dto.ts
@@ -1,0 +1,5 @@
+export interface RiskResponseDto {
+  riskScore: number; // 1-100
+  riskLevel: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+  reasons: string[];
+}

--- a/backend/src/risk/risk.controller.ts
+++ b/backend/src/risk/risk.controller.ts
@@ -1,0 +1,14 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { RiskService } from './risk.service';
+import { EvaluateRiskDto } from './dto/evaluate-risk.dto';
+import { RiskResponseDto } from './dto/risk-response.dto';
+
+@Controller('risk')
+export class RiskController {
+  constructor(private readonly riskService: RiskService) {}
+
+  @Post('evaluate')
+  evaluate(@Body() body: EvaluateRiskDto): RiskResponseDto {
+    return this.riskService.evaluate(body);
+  }
+}

--- a/backend/src/risk/risk.module.ts
+++ b/backend/src/risk/risk.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RiskController } from './risk.controller';
+import { RiskService } from './risk.service';
+
+@Module({
+  controllers: [RiskController],
+  providers: [RiskService],
+  exports: [RiskService],
+})
+export class RiskModule {}

--- a/backend/src/risk/risk.service.ts
+++ b/backend/src/risk/risk.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+import { EvaluateRiskDto, CourtCaseDto, EncumbranceDto } from './dto/evaluate-risk.dto';
+import { RiskResponseDto } from './dto/risk-response.dto';
+
+@Injectable()
+export class RiskService {
+  evaluate(input: EvaluateRiskDto): RiskResponseDto {
+    let score = 0;
+    const reasons: string[] = [];
+
+    // Parties
+    const parties = input.parties || [];
+    if (parties.length > 4) {
+      score += 10;
+      reasons.push('Unusually many parties involved');
+    }
+    if (parties.some(p => ['unknown', 'agent'].includes((p.role || '').toLowerCase()))) {
+      score += 8;
+      reasons.push('Presence of agents/unknown party roles');
+    }
+
+    // Court cases
+    const cases: CourtCaseDto[] = input.courtCases || [];
+    const activeOrPending = cases.filter(c => ['active', 'pending'].includes((c.status || '').toLowerCase())).length;
+    if (activeOrPending > 0) {
+      score += Math.min(30, activeOrPending * 15);
+      reasons.push(`${activeOrPending} active/pending court case(s)`);
+    }
+    const appealed = cases.filter(c => (c.status || '').toLowerCase() === 'appealed').length;
+    if (appealed > 0) {
+      score += Math.min(15, appealed * 10);
+      reasons.push('Appealed case(s) associated with property');
+    }
+
+    // Encumbrances
+    const encs: EncumbranceDto[] = input.encumbrances || [];
+    if (encs.length > 0) {
+      score += Math.min(25, encs.length * 8);
+      reasons.push('Registered encumbrances present');
+    }
+    if (encs.some(e => /lien|caveat|foreclos/i.test(e.type))) {
+      score += 10;
+      reasons.push('Severe encumbrance detected (lien/caveat)');
+    }
+
+    // Property flags
+    const prop = input.property || {} as any;
+    if (prop.titleStatus && /disput|provisional/i.test(prop.titleStatus)) {
+      score += 20;
+      reasons.push(`Title status flagged: ${prop.titleStatus}`);
+    }
+    if (prop.surveyMismatch) {
+      score += 12;
+      reasons.push('Survey/measurement mismatch');
+    }
+    if (prop.overlappingClaims) {
+      score += 20;
+      reasons.push('Overlapping claims on parcel');
+    }
+
+    // History signals
+    const historyDisputes = (input.history?.disputes || []).length;
+    if (historyDisputes > 0) {
+      score += Math.min(20, historyDisputes * 7);
+      reasons.push('Previous disputes in property history');
+    }
+
+    // Normalize and clamp
+    score = Math.max(1, Math.min(100, Math.round(score)));
+
+    // Risk level mapping
+    let level: RiskResponseDto['riskLevel'] = 'LOW';
+    if (score >= 80) level = 'CRITICAL';
+    else if (score >= 60) level = 'HIGH';
+    else if (score >= 35) level = 'MEDIUM';
+
+    // Ensure at least one reason
+    if (reasons.length === 0) {
+      reasons.push('No significant risk indicators found');
+      score = 5;
+      level = 'LOW';
+    }
+
+    return { riskScore: score, riskLevel: level, reasons };
+  }
+}


### PR DESCRIPTION
closes #13 

## Summary
Implements a new risk evaluation service that accepts structured land document data and returns a dispute risk score with level and reasons. Uses simple rule-based logic (mock-friendly) and DTO validation.

## Key Changes
- Added [RiskModule](cci:2://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/risk.module.ts:4:0-9:26) with controller, service, and DTOs.
- Exposed `POST /risk/evaluate` in [src/risk/risk.controller.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/risk.controller.ts:0:0-0:0).
- Implemented rule-based scoring in [src/risk/risk.service.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/risk.service.ts:0:0-0:0).
- Enabled global DTO validation via `ValidationPipe` in [src/main.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/main.ts:0:0-0:0).
- Registered module in [src/app.module.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/app.module.ts:0:0-0:0).

## New Endpoint
- Method: POST
- Route: `/risk/evaluate`
- Controller: [src/risk/risk.controller.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/risk.controller.ts:0:0-0:0) (`RiskController.evaluate()`)

## DTOs
- Input: [src/risk/dto/evaluate-risk.dto.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/dto/evaluate-risk.dto.ts:0:0-0:0)
  - `parties[]`, `courtCases[]`, `encumbrances[]`, `property`, `history`, [extra](cci:1://file:///Users/mustang/Desktop/SMALDA/backend/src/risk-analysis/risk-analysis.service.ts:260:2-287:3)
- Output: [src/risk/dto/risk-response.dto.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/dto/risk-response.dto.ts:0:0-0:0)
  - `{ riskScore: number (1–100), riskLevel: 'LOW'|'MEDIUM'|'HIGH'|'CRITICAL', reasons: string[] }`

## Scoring Logic (Mock Rules)
- Adds points for:
  - Many parties; unknown/agent roles
  - Active/pending/appealed court cases
  - Encumbrances (lien/caveat/foreclose weigh higher)
  - Title status (disputed/provisional), survey mismatch, overlapping claims
  - Historical disputes
- Maps score to risk levels:
  - 1–34 LOW, 35–59 MEDIUM, 60–79 HIGH, 80–100 CRITICAL

## How to Test
1. Start backend: `npm install && npm run start:dev` (cwd: `backend/`)
2. POST to `http://localhost:3000/risk/evaluate` with JSON body:
   - Include `parties`, optional `courtCases`, `encumbrances`, `property`, `history`
3. Verify response includes `riskScore`, `riskLevel`, and `reasons`.

## Acceptance Criteria
- [x] Input: document details (parties, court cases, etc.)
- [x] Output: risk score (1–100), risk level, reasons
- [x] API Route: POST `/risk/evaluate`
- [x] Mock Logic Allowed: Implemented rule-based mock

## Files Added/Updated
- Added: [src/risk/risk.module.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/risk.module.ts:0:0-0:0)
- Added: [src/risk/risk.controller.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/risk.controller.ts:0:0-0:0)
- Added: [src/risk/risk.service.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/risk.service.ts:0:0-0:0)
- Added: [src/risk/dto/evaluate-risk.dto.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/dto/evaluate-risk.dto.ts:0:0-0:0)
- Added: [src/risk/dto/risk-response.dto.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/dto/risk-response.dto.ts:0:0-0:0)
- Updated: [src/app.module.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/app.module.ts:0:0-0:0) (import [RiskModule](cci:2://file:///Users/mustang/Desktop/SMALDA/backend/src/risk/risk.module.ts:4:0-9:26))
- Updated: [src/main.ts](cci:7://file:///Users/mustang/Desktop/SMALDA/backend/src/main.ts:0:0-0:0) (global `ValidationPipe`)