### PR TITLE
feat: implement VerificationWorkflowModule for document pipeline life…

### DIFF
--- a/backend/src/verification-workflow/dto/initiate-workflow.dto.ts
+++ b/backend/src/verification-workflow/dto/initiate-workflow.dto.ts
@@ -1,0 +1,8 @@
+import { IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InitiateWorkflowDto {
+  @ApiProperty({ description: 'UUID of the document to initiate verification for' })
+  @IsUUID()
+  documentId: string;
+}

--- a/backend/src/verification-workflow/dto/record-anchor.dto.ts
+++ b/backend/src/verification-workflow/dto/record-anchor.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RecordAnchorDto {
+  @ApiProperty({
+    description: 'The Stellar transaction ID confirming the document has been anchored on-chain',
+    example: 'a1b2c3d4e5f6...',
+  })
+  @IsString()
+  @IsNotEmpty()
+  stellarTransactionId: string;
+}

--- a/backend/src/verification-workflow/dto/transition-workflow.dto.ts
+++ b/backend/src/verification-workflow/dto/transition-workflow.dto.ts
@@ -1,0 +1,20 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { WorkflowState } from '../enums/workflow-state.enum';
+
+export class TransitionWorkflowDto {
+  @ApiProperty({
+    enum: WorkflowState,
+    description: 'The target state to transition the workflow into',
+    example: WorkflowState.HASHING,
+  })
+  @IsEnum(WorkflowState)
+  newState: WorkflowState;
+
+  @ApiPropertyOptional({
+    description: 'Optional human-readable note explaining the reason for this transition',
+  })
+  @IsString()
+  @IsOptional()
+  note?: string;
+}

--- a/backend/src/verification-workflow/entities/verification-workflow.entity.ts
+++ b/backend/src/verification-workflow/entities/verification-workflow.entity.ts
@@ -1,0 +1,74 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { WorkflowState } from '../enums/workflow-state.enum';
+
+export interface WorkflowHistoryEntry {
+  state: WorkflowState;
+  timestamp: string; // ISO-8601
+  note?: string;
+}
+
+@Entity('verification_workflows')
+@Index(['documentId'])
+@Index(['currentState'])
+export class VerificationWorkflow {
+  @ApiProperty({ description: 'Unique identifier (UUID)' })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // Foreign key referencing UploadedDocument (stored as plain UUID;
+  // add a TypeORM relation once the UploadedDocument entity is available)
+  @ApiProperty({ description: 'UUID of the document being verified' })
+  @Column({ type: 'uuid' })
+  documentId: string;
+
+  @ApiProperty({
+    enum: WorkflowState,
+    description: 'Current state of the verification pipeline',
+  })
+  @Column({ type: 'enum', enum: WorkflowState, default: WorkflowState.SUBMITTED })
+  currentState: WorkflowState;
+
+  @ApiPropertyOptional({
+    description: 'Stellar transaction ID once the document has been anchored',
+  })
+  @Column({ type: 'varchar', nullable: true, default: null })
+  stellarTransactionId: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Human-readable error message when the workflow reaches FAILED state',
+  })
+  @Column({ type: 'text', nullable: true, default: null })
+  errorMessage: string | null;
+
+  @ApiProperty({ description: 'Timestamp when the workflow was initiated' })
+  @CreateDateColumn()
+  submittedAt: Date;
+
+  @ApiPropertyOptional({
+    description: 'Timestamp when the workflow reached a terminal state (ANCHORED / FAILED / REJECTED)',
+  })
+  @Column({ type: 'timestamp', nullable: true, default: null })
+  completedAt: Date | null;
+
+  @ApiProperty({
+    description: 'Ordered log of every state the workflow has passed through',
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        state: { type: 'string', enum: Object.values(WorkflowState) },
+        timestamp: { type: 'string', format: 'date-time' },
+        note: { type: 'string' },
+      },
+    },
+  })
+  @Column({ type: 'jsonb', default: [] })
+  history: WorkflowHistoryEntry[];
+}

--- a/backend/src/verification-workflow/enums/workflow-state.enum.ts
+++ b/backend/src/verification-workflow/enums/workflow-state.enum.ts
@@ -1,0 +1,38 @@
+export enum WorkflowState {
+  SUBMITTED = 'SUBMITTED',
+  HASHING = 'HASHING',
+  ANALYZING = 'ANALYZING',
+  AWAITING_BLOCKCHAIN = 'AWAITING_BLOCKCHAIN',
+  ANCHORED = 'ANCHORED',
+  FAILED = 'FAILED',
+  REJECTED = 'REJECTED',
+}
+
+/** Terminal states — no further transitions are allowed from these. */
+export const TERMINAL_STATES = new Set<WorkflowState>([
+  WorkflowState.ANCHORED,
+  WorkflowState.FAILED,
+  WorkflowState.REJECTED,
+]);
+
+/** Defines which states a workflow may move to from each given state. */
+export const VALID_TRANSITIONS: Record<WorkflowState, WorkflowState[]> = {
+  [WorkflowState.SUBMITTED]: [
+    WorkflowState.HASHING,
+    WorkflowState.FAILED,
+    WorkflowState.REJECTED,
+  ],
+  [WorkflowState.HASHING]: [WorkflowState.ANALYZING, WorkflowState.FAILED],
+  [WorkflowState.ANALYZING]: [
+    WorkflowState.AWAITING_BLOCKCHAIN,
+    WorkflowState.FAILED,
+    WorkflowState.REJECTED,
+  ],
+  [WorkflowState.AWAITING_BLOCKCHAIN]: [
+    WorkflowState.ANCHORED,
+    WorkflowState.FAILED,
+  ],
+  [WorkflowState.ANCHORED]: [],
+  [WorkflowState.FAILED]: [],
+  [WorkflowState.REJECTED]: [],
+};

--- a/backend/src/verification-workflow/verification-workflow.controller.ts
+++ b/backend/src/verification-workflow/verification-workflow.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { InitiateWorkflowDto } from './dto/initiate-workflow.dto';
+import { RecordAnchorDto } from './dto/record-anchor.dto';
+import { TransitionWorkflowDto } from './dto/transition-workflow.dto';
+import { VerificationWorkflow } from './entities/verification-workflow.entity';
+import { WorkflowState } from './enums/workflow-state.enum';
+import { VerificationWorkflowService } from './verification-workflow.service';
+
+@ApiTags('Verification Workflows')
+@Controller('verification-workflows')
+export class VerificationWorkflowController {
+  constructor(
+    private readonly verificationWorkflowService: VerificationWorkflowService,
+  ) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Initiate a new verification workflow for a document' })
+  @ApiResponse({ status: 201, description: 'Workflow created in SUBMITTED state', type: VerificationWorkflow })
+  initiate(@Body() dto: InitiateWorkflowDto): Promise<VerificationWorkflow> {
+    return this.verificationWorkflowService.initiate(dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List all workflows, optionally filtered by state' })
+  @ApiQuery({
+    name: 'state',
+    enum: WorkflowState,
+    required: false,
+    description: 'Filter results to a specific workflow state',
+  })
+  @ApiResponse({ status: 200, description: 'List of workflows', type: [VerificationWorkflow] })
+  findAll(@Query('state') state?: WorkflowState): Promise<VerificationWorkflow[]> {
+    return this.verificationWorkflowService.findAll(state);
+  }
+
+  @Get('document/:documentId')
+  @ApiOperation({ summary: 'Get the current workflow status for a document' })
+  @ApiParam({ name: 'documentId', description: 'UUID of the document' })
+  @ApiResponse({ status: 200, description: 'Most recent workflow for the document', type: VerificationWorkflow })
+  findByDocument(
+    @Param('documentId', ParseUUIDPipe) documentId: string,
+  ): Promise<VerificationWorkflow | null> {
+    return this.verificationWorkflowService.findByDocument(documentId);
+  }
+
+  @Patch(':id/transition')
+  @ApiOperation({ summary: 'Move a workflow to a new state (enforces valid transitions)' })
+  @ApiParam({ name: 'id', description: 'UUID of the workflow' })
+  @ApiResponse({ status: 200, description: 'Workflow after the transition', type: VerificationWorkflow })
+  @ApiResponse({ status: 400, description: 'Invalid state transition' })
+  @ApiResponse({ status: 404, description: 'Workflow not found' })
+  transition(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: TransitionWorkflowDto,
+  ): Promise<VerificationWorkflow> {
+    return this.verificationWorkflowService.transition(id, dto);
+  }
+
+  @Patch(':id/anchor')
+  @ApiOperation({ summary: 'Record a Stellar anchor and mark the workflow as ANCHORED' })
+  @ApiParam({ name: 'id', description: 'UUID of the workflow' })
+  @ApiResponse({ status: 200, description: 'Workflow marked as ANCHORED with transaction ID', type: VerificationWorkflow })
+  @ApiResponse({ status: 400, description: 'Workflow is not in AWAITING_BLOCKCHAIN state' })
+  @ApiResponse({ status: 404, description: 'Workflow not found' })
+  recordAnchor(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: RecordAnchorDto,
+  ): Promise<VerificationWorkflow> {
+    return this.verificationWorkflowService.recordAnchor(id, dto);
+  }
+}

--- a/backend/src/verification-workflow/verification-workflow.module.ts
+++ b/backend/src/verification-workflow/verification-workflow.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { VerificationWorkflow } from './entities/verification-workflow.entity';
+import { VerificationWorkflowController } from './verification-workflow.controller';
+import { VerificationWorkflowService } from './verification-workflow.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([VerificationWorkflow])],
+  controllers: [VerificationWorkflowController],
+  providers: [VerificationWorkflowService],
+  exports: [VerificationWorkflowService],
+})
+export class VerificationWorkflowModule {}

--- a/backend/src/verification-workflow/verification-workflow.service.ts
+++ b/backend/src/verification-workflow/verification-workflow.service.ts
@@ -1,0 +1,128 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  VerificationWorkflow,
+  WorkflowHistoryEntry,
+} from './entities/verification-workflow.entity';
+import { InitiateWorkflowDto } from './dto/initiate-workflow.dto';
+import { TransitionWorkflowDto } from './dto/transition-workflow.dto';
+import { RecordAnchorDto } from './dto/record-anchor.dto';
+import {
+  TERMINAL_STATES,
+  VALID_TRANSITIONS,
+  WorkflowState,
+} from './enums/workflow-state.enum';
+
+@Injectable()
+export class VerificationWorkflowService {
+  constructor(
+    @InjectRepository(VerificationWorkflow)
+    private readonly workflowRepository: Repository<VerificationWorkflow>,
+  ) {}
+
+  async initiate(dto: InitiateWorkflowDto): Promise<VerificationWorkflow> {
+    const initialEntry: WorkflowHistoryEntry = {
+      state: WorkflowState.SUBMITTED,
+      timestamp: new Date().toISOString(),
+      note: 'Workflow initiated',
+    };
+
+    const workflow = this.workflowRepository.create({
+      documentId: dto.documentId,
+      currentState: WorkflowState.SUBMITTED,
+      history: [initialEntry],
+    });
+
+    return this.workflowRepository.save(workflow);
+  }
+
+  async transition(
+    workflowId: string,
+    dto: TransitionWorkflowDto,
+  ): Promise<VerificationWorkflow> {
+    const workflow = await this.findWorkflowOrFail(workflowId);
+    const { newState, note } = dto;
+
+    this.assertValidTransition(workflow.currentState, newState);
+
+    const historyEntry: WorkflowHistoryEntry = {
+      state: newState,
+      timestamp: new Date().toISOString(),
+      ...(note && { note }),
+    };
+
+    workflow.currentState = newState;
+    workflow.history = [...workflow.history, historyEntry];
+
+    if (TERMINAL_STATES.has(newState)) {
+      workflow.completedAt = new Date();
+    }
+
+    return this.workflowRepository.save(workflow);
+  }
+
+  async findByDocument(documentId: string): Promise<VerificationWorkflow | null> {
+    return this.workflowRepository.findOne({
+      where: { documentId },
+      order: { submittedAt: 'DESC' },
+    });
+  }
+
+  async findAll(state?: WorkflowState): Promise<VerificationWorkflow[]> {
+    const where = state ? { currentState: state } : {};
+    return this.workflowRepository.find({
+      where,
+      order: { submittedAt: 'DESC' },
+    });
+  }
+
+  async recordAnchor(
+    workflowId: string,
+    dto: RecordAnchorDto,
+  ): Promise<VerificationWorkflow> {
+    const workflow = await this.findWorkflowOrFail(workflowId);
+
+    this.assertValidTransition(workflow.currentState, WorkflowState.ANCHORED);
+
+    const historyEntry: WorkflowHistoryEntry = {
+      state: WorkflowState.ANCHORED,
+      timestamp: new Date().toISOString(),
+      note: `Anchored on Stellar — tx: ${dto.stellarTransactionId}`,
+    };
+
+    workflow.currentState = WorkflowState.ANCHORED;
+    workflow.stellarTransactionId = dto.stellarTransactionId;
+    workflow.completedAt = new Date();
+    workflow.history = [...workflow.history, historyEntry];
+
+    return this.workflowRepository.save(workflow);
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private async findWorkflowOrFail(id: string): Promise<VerificationWorkflow> {
+    const workflow = await this.workflowRepository.findOne({ where: { id } });
+    if (!workflow) {
+      throw new NotFoundException(`Verification workflow with ID ${id} not found`);
+    }
+    return workflow;
+  }
+
+  private assertValidTransition(
+    from: WorkflowState,
+    to: WorkflowState,
+  ): void {
+    const allowed = VALID_TRANSITIONS[from];
+    if (!allowed.includes(to)) {
+      throw new BadRequestException(
+        `Invalid state transition: ${from} → ${to}. ` +
+          `Allowed: [${allowed.join(', ') || 'none — this is a terminal state'}]`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

  - Adds `VerificationWorkflow` TypeORM entity with a JSONB `history` column that
    logs every state transition with timestamp and optional note
  - Implements a strict state machine via `VALID_TRANSITIONS` — invalid transitions
    throw a `400 BadRequestException` with a descriptive error message
  - `VerificationWorkflowService` exposes `initiate`, `transition`, `findByDocument`,
    `findAll`, and `recordAnchor` methods
  - `recordAnchor` is a dedicated path to `ANCHORED` that stamps `stellarTransactionId`
    and `completedAt` in a single atomic operation
  - Terminal states (`ANCHORED`, `FAILED`, `REJECTED`) automatically set `completedAt`
    and block further transitions
  - Registers `VerificationWorkflowModule` in `AppModule` alongside `RiskIndicatorModule`

  ## State Machine

  SUBMITTED → HASHING | FAILED | REJECTED
  HASHING → ANALYZING | FAILED
  ANALYZING → AWAITING_BLOCKCHAIN | FAILED | REJECTED
  AWAITING_BLOCKCHAIN → ANCHORED | FAILED
  ANCHORED / FAILED / REJECTED → (terminal)

  ## Endpoints

  | Method  | Path                                              | Description                        |
  |---------|---------------------------------------------------|------------------------------------|
  | POST    | /api/verification-workflows                       | Initiate workflow in SUBMITTED state |
  | GET     | /api/verification-workflows?state=                | List all workflows (filterable)    |
  | GET     | /api/verification-workflows/document/:documentId  | Get current workflow for a document |
  | PATCH   | /api/verification-workflows/:id/transition        | Transition to a new state          |
  | PATCH   | /api/verification-workflows/:id/anchor            | Record Stellar anchor → ANCHORED   |

closes #166 