### PR TITLE
feat: implement DocumentHashingModule with SHA-256 fingerprinting for…

### DIFF
--- a/backend/src/document-hashing/document-hashing.module.ts
+++ b/backend/src/document-hashing/document-hashing.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UploadedDocument } from './entities/uploaded-document.entity';
+import { DocumentHashingService } from './document-hashing.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UploadedDocument])],
+  providers: [DocumentHashingService],
+  exports: [DocumentHashingService],
+})
+export class DocumentHashingModule {}

--- a/backend/src/document-hashing/document-hashing.service.ts
+++ b/backend/src/document-hashing/document-hashing.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import { UploadedDocument } from './entities/uploaded-document.entity';
+
+@Injectable()
+export class DocumentHashingService {
+  constructor(
+    @InjectRepository(UploadedDocument)
+    private readonly documentRepository: Repository<UploadedDocument>,
+  ) {}
+
+  /**
+   * Reads the file at `filePath` as a stream and returns its hex-encoded SHA-256 hash.
+   * Streaming avoids loading the entire file into memory, making it safe for large documents.
+   */
+  computeHash(filePath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const hash = crypto.createHash('sha256');
+      const fileStream = fs.createReadStream(filePath);
+
+      fileStream.on('error', reject);
+      fileStream.on('data', (chunk: Buffer) => hash.update(chunk));
+      fileStream.on('end', () => resolve(hash.digest('hex')));
+    });
+  }
+
+  /**
+   * Computes a hex-encoded SHA-256 hash from an in-memory buffer.
+   * Useful when the file bytes are already available (e.g. after Multer upload).
+   */
+  computeHashFromBuffer(buffer: Buffer): string {
+    return crypto.createHash('sha256').update(buffer).digest('hex');
+  }
+
+  /**
+   * Recomputes the hash of the file at `filePath` and compares it against `expectedHash`.
+   * Returns true only when the hashes match exactly (constant-time comparison via timingSafeEqual).
+   */
+  async verifyHash(filePath: string, expectedHash: string): Promise<boolean> {
+    const actualHash = await this.computeHash(filePath);
+
+    // Use timingSafeEqual to prevent timing-based side-channel attacks
+    const actual = Buffer.from(actualHash, 'hex');
+    const expected = Buffer.from(expectedHash, 'hex');
+
+    if (actual.length !== expected.length) {
+      return false;
+    }
+
+    return crypto.timingSafeEqual(actual, expected);
+  }
+
+  /**
+   * Internal method: looks up the document by ID, computes the SHA-256 hash of its file,
+   * persists the result back to the `sha256Hash` column, and returns the updated record.
+   *
+   * Intended to be called by other services (e.g. after a file upload completes)
+   * rather than exposed directly via an HTTP endpoint.
+   */
+  async hashAndStore(documentId: string): Promise<UploadedDocument> {
+    const document = await this.documentRepository.findOne({
+      where: { id: documentId },
+    });
+
+    if (!document) {
+      throw new NotFoundException(
+        `UploadedDocument with ID ${documentId} not found`,
+      );
+    }
+
+    document.sha256Hash = await this.computeHash(document.filePath);
+
+    return this.documentRepository.save(document);
+  }
+}

--- a/backend/src/document-hashing/entities/uploaded-document.entity.ts
+++ b/backend/src/document-hashing/entities/uploaded-document.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+@Entity('uploaded_documents')
+export class UploadedDocument {
+  @ApiProperty({ description: 'Unique identifier (UUID)' })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({ description: 'Original filename as provided by the uploader' })
+  @Column()
+  originalName: string;
+
+  @ApiProperty({ description: 'Absolute path to the file on disk' })
+  @Column()
+  filePath: string;
+
+  @ApiPropertyOptional({ description: 'MIME type of the uploaded file' })
+  @Column({ nullable: true })
+  mimeType: string | null;
+
+  @ApiPropertyOptional({ description: 'File size in bytes' })
+  @Column({ type: 'bigint', nullable: true })
+  size: number | null;
+
+  // Populated by DocumentHashingService.hashAndStore() after upload — not set during initial record creation
+  @ApiPropertyOptional({
+    description: 'Hex-encoded SHA-256 fingerprint of the file, computed post-upload',
+  })
+  @Column({ type: 'varchar', length: 64, nullable: true, default: null })
+  sha256Hash: string | null;
+
+  @ApiProperty({ description: 'Timestamp when the document was uploaded' })
+  @CreateDateColumn()
+  uploadedAt: Date;
+}


### PR DESCRIPTION
… uploaded documentsDescription:
  ## Summary

  - Introduces the canonical `UploadedDocument` TypeORM entity with a nullable
    `sha256Hash` column (varchar 64) populated post-upload, not during initial record creation
  - Implements `DocumentHashingService` with four methods:
    - `computeHash(filePath)` — streams the file to avoid loading large docs into memory
    - `computeHashFromBuffer(buffer)` — synchronous hash from an in-memory buffer (post-Multer use case)
    - `verifyHash(filePath, expectedHash)` — uses `crypto.timingSafeEqual` to prevent timing-based side-channel attacks
    - `hashAndStore(documentId)` — internal method; resolves file path from DB, computes hash, and persists it back
  - No controller — `DocumentHashingService` is exported for consumption by other modules
    (e.g. `VerificationWorkflowModule` after a file upload completes)
  - Uses Node's built-in `crypto` module exclusively — no external hashing dependencies
  - Registers `DocumentHashingModule` in `AppModule`

  ## Notes

  - `UploadedDocument` is the shared entity referenced by `RiskIndicatorModule` (documentId FK)
    and `VerificationWorkflowModule` (documentId FK) — those modules should import it from here
  - `hashAndStore` is intentionally not exposed via HTTP; it is meant to be called
    internally after an upload pipeline step completes
    
    closes #164 