### PR TITLE
feat: implement DocumentUploadModule for secure land document file up…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,4 +27,7 @@ MAIL_FROM=noreply@smalda.com
 THROTTLE_TTL=60
 THROTTLE_LIMIT=10
 
+# File Upload
+UPLOAD_DIR=./uploads
+
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { RiskIndicatorModule } from './risk-indicator/risk-indicator.module';
+import { DocumentUploadModule } from './document-upload/document-upload.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { RiskIndicatorModule } from './risk-indicator/risk-indicator.module';
       }),
     }),
     RiskIndicatorModule,
+    DocumentUploadModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/document-upload/document-upload.controller.ts
+++ b/backend/src/document-upload/document-upload.controller.ts
@@ -1,0 +1,56 @@
+import {
+  Controller,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiConsumes,
+  ApiBody,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { DocumentUploadService } from './document-upload.service';
+import { UploadResponseDto } from './dto/upload-response.dto';
+
+@ApiTags('Document Upload')
+@Controller('documents')
+export class DocumentUploadController {
+  constructor(private readonly documentUploadService: DocumentUploadService) {}
+
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({ summary: 'Upload a land ownership document (PDF or image)' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'PDF, JPEG, or PNG file (max 10 MB)',
+        },
+      },
+      required: ['file'],
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'File uploaded successfully. Returns stored document metadata.',
+    type: UploadResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'No file provided or unsupported file type.' })
+  async uploadDocument(
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<UploadResponseDto> {
+    if (!file) {
+      throw new BadRequestException('No file provided');
+    }
+
+    return this.documentUploadService.saveUpload(file);
+  }
+}

--- a/backend/src/document-upload/document-upload.module.ts
+++ b/backend/src/document-upload/document-upload.module.ts
@@ -1,0 +1,60 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MulterModule } from '@nestjs/platform-express';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { diskStorage } from 'multer';
+import { extname, resolve } from 'path';
+import { mkdirSync } from 'fs';
+import { BadRequestException } from '@nestjs/common';
+import { DocumentUploadController } from './document-upload.controller';
+import { DocumentUploadService } from './document-upload.service';
+import { UploadedDocument } from './entities/uploaded-document.entity';
+
+const ALLOWED_MIME_TYPES = ['application/pdf', 'image/jpeg', 'image/png'];
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+@Module({
+  imports: [
+    ConfigModule,
+    TypeOrmModule.forFeature([UploadedDocument]),
+    MulterModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        storage: diskStorage({
+          destination: (_req, _file, cb) => {
+            const uploadDir = resolve(
+              configService.get<string>('UPLOAD_DIR') || './uploads',
+            );
+            mkdirSync(uploadDir, { recursive: true });
+            cb(null, uploadDir);
+          },
+          filename: (_req, file, cb) => {
+            const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+            const ext = extname(file.originalname);
+            cb(null, `${uniqueSuffix}${ext}`);
+          },
+        }),
+        fileFilter: (_req, file, cb) => {
+          if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+            cb(null, true);
+          } else {
+            cb(
+              new BadRequestException(
+                `Unsupported file type "${file.mimetype}". Accepted types: ${ALLOWED_MIME_TYPES.join(', ')}`,
+              ),
+              false,
+            );
+          }
+        },
+        limits: {
+          fileSize: MAX_FILE_SIZE_BYTES,
+        },
+      }),
+    }),
+  ],
+  controllers: [DocumentUploadController],
+  providers: [DocumentUploadService],
+  exports: [DocumentUploadService],
+})
+export class DocumentUploadModule {}

--- a/backend/src/document-upload/document-upload.service.ts
+++ b/backend/src/document-upload/document-upload.service.ts
@@ -1,0 +1,55 @@
+import {
+  Injectable,
+  NotFoundException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { unlinkSync } from 'fs';
+import { UploadedDocument } from './entities/uploaded-document.entity';
+
+@Injectable()
+export class DocumentUploadService {
+  constructor(
+    @InjectRepository(UploadedDocument)
+    private readonly uploadedDocumentRepository: Repository<UploadedDocument>,
+  ) {}
+
+  async saveUpload(file: Express.Multer.File): Promise<UploadedDocument> {
+    const document = this.uploadedDocumentRepository.create({
+      originalName: file.originalname,
+      storagePath: file.path,
+      mimeType: file.mimetype,
+      sizeBytes: file.size,
+    });
+
+    return this.uploadedDocumentRepository.save(document);
+  }
+
+  async findById(id: string): Promise<UploadedDocument> {
+    const document = await this.uploadedDocumentRepository.findOne({
+      where: { id },
+    });
+
+    if (!document) {
+      throw new NotFoundException(`Document with ID "${id}" not found`);
+    }
+
+    return document;
+  }
+
+  async deleteUpload(id: string): Promise<void> {
+    const document = await this.findById(id);
+
+    try {
+      unlinkSync(document.storagePath);
+    } catch {
+      // File may have already been removed from disk; proceed to clean up DB record
+      throw new InternalServerErrorException(
+        `Failed to delete file at path "${document.storagePath}"`,
+      );
+    }
+
+    await this.uploadedDocumentRepository.remove(document);
+  }
+}

--- a/backend/src/document-upload/dto/upload-response.dto.ts
+++ b/backend/src/document-upload/dto/upload-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UploadResponseDto {
+  @ApiProperty({ description: 'Unique identifier of the stored document (UUID)' })
+  id: string;
+
+  @ApiProperty({ description: 'Original filename as provided by the uploader' })
+  originalName: string;
+
+  @ApiProperty({ description: 'Absolute server-side path where the file is stored' })
+  storagePath: string;
+
+  @ApiProperty({ description: 'MIME type of the uploaded file' })
+  mimeType: string;
+
+  @ApiProperty({ description: 'File size in bytes' })
+  sizeBytes: number;
+
+  @ApiProperty({ description: 'Timestamp when the document was uploaded' })
+  uploadedAt: Date;
+}

--- a/backend/src/document-upload/entities/uploaded-document.entity.ts
+++ b/backend/src/document-upload/entities/uploaded-document.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('document_uploads')
+export class UploadedDocument {
+  @ApiProperty({ description: 'Unique identifier (UUID)' })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({ description: 'Original filename as provided by the uploader' })
+  @Column()
+  originalName: string;
+
+  @ApiProperty({ description: 'Absolute server-side path where the file is stored' })
+  @Column()
+  storagePath: string;
+
+  @ApiProperty({ description: 'MIME type of the uploaded file' })
+  @Column()
+  mimeType: string;
+
+  @ApiProperty({ description: 'File size in bytes' })
+  @Column({ type: 'bigint' })
+  sizeBytes: number;
+
+  @ApiProperty({ description: 'Timestamp when the document was uploaded' })
+  @CreateDateColumn()
+  uploadedAt: Date;
+}


### PR DESCRIPTION
…loads## Summary

  Adds a standalone `DocumentUploadModule` that handles secure file uploads
  for land ownership documents (PDFs and images), persists file metadata to
  PostgreSQL via TypeORM, and exposes a REST endpoint for consumers.

  ## Changes

  ### New module — `src/document-upload/`
  - **`entities/uploaded-document.entity.ts`** — `UploadedDocument` TypeORM
    entity mapped to the `document_uploads` table with fields: `id` (UUID),
    `originalName`, `storagePath`, `mimeType`, `sizeBytes`, `uploadedAt`
  - **`dto/upload-response.dto.ts`** — Swagger-annotated response DTO returned
    on successful upload
  - **`document-upload.service.ts`** — `DocumentUploadService` with three
    methods: `saveUpload`, `findById`, and `deleteUpload` (removes file from
    disk and DB record)
  - **`document-upload.module.ts`** — Configures `MulterModule` via
    `registerAsync`; reads `UPLOAD_DIR` from env, enforces allowed MIME types
    and 10 MB size cap at the module level
  - **`document-upload.controller.ts`** — Exposes `POST /api/documents/upload`
    with full Swagger documentation

  ### Modified
  - **`src/app.module.ts`** — Registers `DocumentUploadModule`
  - **`.env.example`** — Documents the new `UPLOAD_DIR` variable

  ## Behaviour

  | Concern | Detail |
  |---|---|
  | Accepted types | `application/pdf`, `image/jpeg`, `image/png` |
  | Max file size | 10 MB (enforced by multer `limits`) |
  | Storage | Local filesystem at path set by `UPLOAD_DIR` env var (default `./uploads`) |
  | Filename | Timestamped unique suffix — avoids collisions |
  | Upload dir | Created automatically if it does not exist |
  | Response | Full document metadata including the stable UUID for downstream use |

  ## Environment variable

  Add to your `.env`:
  UPLOAD_DIR=./uploads
  
  closes #163 