### PR TITLE
feat: implement LandRecordModule as the core domain entity for land p…

### DIFF
--- a/backend/src/land-record/dto/create-land-record.dto.ts
+++ b/backend/src/land-record/dto/create-land-record.dto.ts
@@ -1,0 +1,69 @@
+import {
+  IsDateString,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { LandRecordStatus } from '../enums/land-record.enum';
+
+export class CreateLandRecordDto {
+  @ApiProperty({
+    description: 'Unique parcel identifier assigned by a land registry',
+    example: 'PARCEL-2024-00123',
+  })
+  @IsString()
+  @IsNotEmpty()
+  parcelId: string;
+
+  @ApiProperty({
+    description: 'Human-readable address or coordinates of the parcel',
+    example: '45 Broad Street, Lagos, Nigeria',
+  })
+  @IsString()
+  @IsNotEmpty()
+  location: string;
+
+  @ApiProperty({
+    description: 'Land area in square meters',
+    example: 500.75,
+  })
+  @IsNumber()
+  @IsPositive()
+  area: number;
+
+  @ApiProperty({
+    description: 'Full name of the current owner',
+    example: 'Emeka Okafor',
+  })
+  @IsString()
+  @IsNotEmpty()
+  ownerName: string;
+
+  @ApiPropertyOptional({
+    description: 'Phone number or email address of the owner',
+    example: '+2348012345678',
+  })
+  @IsOptional()
+  @IsString()
+  ownerContact?: string;
+
+  @ApiProperty({
+    description: 'Date the parcel was officially registered (ISO 8601 date)',
+    example: '2024-01-15',
+  })
+  @IsDateString()
+  registrationDate: string;
+
+  @ApiPropertyOptional({
+    enum: LandRecordStatus,
+    description: 'Initial status of the land record (defaults to ACTIVE)',
+    example: LandRecordStatus.ACTIVE,
+  })
+  @IsOptional()
+  @IsEnum(LandRecordStatus)
+  status?: LandRecordStatus;
+}

--- a/backend/src/land-record/dto/filter-land-record.dto.ts
+++ b/backend/src/land-record/dto/filter-land-record.dto.ts
@@ -1,0 +1,22 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { LandRecordStatus } from '../enums/land-record.enum';
+
+export class FilterLandRecordDto {
+  @ApiPropertyOptional({
+    enum: LandRecordStatus,
+    description: 'Filter records by status',
+    example: LandRecordStatus.ACTIVE,
+  })
+  @IsOptional()
+  @IsEnum(LandRecordStatus)
+  status?: LandRecordStatus;
+
+  @ApiPropertyOptional({
+    description: 'Filter records by partial location match (case-insensitive)',
+    example: 'Lagos',
+  })
+  @IsOptional()
+  @IsString()
+  location?: string;
+}

--- a/backend/src/land-record/dto/update-land-record.dto.ts
+++ b/backend/src/land-record/dto/update-land-record.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateLandRecordDto } from './create-land-record.dto';
+
+export class UpdateLandRecordDto extends PartialType(CreateLandRecordDto) {}

--- a/backend/src/land-record/entities/land-record.entity.ts
+++ b/backend/src/land-record/entities/land-record.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { LandRecordStatus } from '../enums/land-record.enum';
+
+@Entity('land_records')
+@Index(['parcelId'], { unique: true })
+@Index(['status'])
+export class LandRecord {
+  @ApiProperty({ description: 'Unique identifier (UUID)' })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({ description: 'Unique parcel identifier assigned by a land registry' })
+  @Column({ unique: true })
+  parcelId: string;
+
+  @ApiProperty({ description: 'Human-readable address or coordinates of the parcel' })
+  @Column()
+  location: string;
+
+  @ApiProperty({ description: 'Land area in square meters', example: 500.75 })
+  @Column({ type: 'decimal', precision: 12, scale: 4 })
+  area: number;
+
+  @ApiProperty({ description: 'Full name of the current owner' })
+  @Column()
+  ownerName: string;
+
+  @ApiPropertyOptional({ description: 'Phone number or email address of the owner' })
+  @Column({ nullable: true, default: null })
+  ownerContact: string | null;
+
+  @ApiProperty({ description: 'Date the parcel was officially registered', example: '2024-01-15' })
+  @Column({ type: 'date' })
+  registrationDate: Date;
+
+  @ApiProperty({ enum: LandRecordStatus, description: 'Current status of the land record' })
+  @Column({ type: 'enum', enum: LandRecordStatus, default: LandRecordStatus.ACTIVE })
+  status: LandRecordStatus;
+
+  @ApiProperty({ description: 'Timestamp when the record was created' })
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Timestamp when the record was last updated' })
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date | null;
+}

--- a/backend/src/land-record/enums/land-record.enum.ts
+++ b/backend/src/land-record/enums/land-record.enum.ts
@@ -1,0 +1,6 @@
+export enum LandRecordStatus {
+  ACTIVE = 'ACTIVE',
+  DISPUTED = 'DISPUTED',
+  TRANSFERRED = 'TRANSFERRED',
+  ARCHIVED = 'ARCHIVED',
+}

--- a/backend/src/land-record/land-record.controller.ts
+++ b/backend/src/land-record/land-record.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { LandRecordService } from './land-record.service';
+import { LandRecord } from './entities/land-record.entity';
+import { CreateLandRecordDto } from './dto/create-land-record.dto';
+import { UpdateLandRecordDto } from './dto/update-land-record.dto';
+import { FilterLandRecordDto } from './dto/filter-land-record.dto';
+
+@ApiTags('Land Records')
+@Controller('land-records')
+export class LandRecordController {
+  constructor(private readonly landRecordService: LandRecordService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new land record' })
+  @ApiResponse({ status: 201, description: 'Land record created', type: LandRecord })
+  @ApiResponse({ status: 400, description: 'Invalid request body' })
+  @ApiResponse({ status: 409, description: 'Parcel ID already exists' })
+  create(@Body() dto: CreateLandRecordDto): Promise<LandRecord> {
+    return this.landRecordService.create(dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List all land records with optional filtering by status and location' })
+  @ApiResponse({ status: 200, description: 'List of land records', type: [LandRecord] })
+  findAll(@Query() filters: FilterLandRecordDto): Promise<LandRecord[]> {
+    return this.landRecordService.findAll(filters);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Retrieve a single land record by ID' })
+  @ApiParam({ name: 'id', description: 'UUID of the land record' })
+  @ApiResponse({ status: 200, description: 'Land record found', type: LandRecord })
+  @ApiResponse({ status: 404, description: 'Land record not found' })
+  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<LandRecord> {
+    return this.landRecordService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update an existing land record' })
+  @ApiParam({ name: 'id', description: 'UUID of the land record' })
+  @ApiResponse({ status: 200, description: 'Land record updated', type: LandRecord })
+  @ApiResponse({ status: 404, description: 'Land record not found' })
+  @ApiResponse({ status: 409, description: 'Parcel ID already taken by another record' })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateLandRecordDto,
+  ): Promise<LandRecord> {
+    return this.landRecordService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Soft-delete a land record' })
+  @ApiParam({ name: 'id', description: 'UUID of the land record' })
+  @ApiResponse({ status: 204, description: 'Land record soft-deleted' })
+  @ApiResponse({ status: 404, description: 'Land record not found' })
+  remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.landRecordService.remove(id);
+  }
+}

--- a/backend/src/land-record/land-record.module.ts
+++ b/backend/src/land-record/land-record.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LandRecord } from './entities/land-record.entity';
+import { LandRecordController } from './land-record.controller';
+import { LandRecordService } from './land-record.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([LandRecord])],
+  controllers: [LandRecordController],
+  providers: [LandRecordService],
+  exports: [LandRecordService],
+})
+export class LandRecordModule {}

--- a/backend/src/land-record/land-record.service.ts
+++ b/backend/src/land-record/land-record.service.ts
@@ -1,0 +1,85 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FindOptionsWhere, ILike, Repository } from 'typeorm';
+import { LandRecord } from './entities/land-record.entity';
+import { CreateLandRecordDto } from './dto/create-land-record.dto';
+import { UpdateLandRecordDto } from './dto/update-land-record.dto';
+import { FilterLandRecordDto } from './dto/filter-land-record.dto';
+
+@Injectable()
+export class LandRecordService {
+  constructor(
+    @InjectRepository(LandRecord)
+    private readonly landRecordRepository: Repository<LandRecord>,
+  ) {}
+
+  async create(dto: CreateLandRecordDto): Promise<LandRecord> {
+    const existing = await this.landRecordRepository.findOne({
+      where: { parcelId: dto.parcelId },
+    });
+
+    if (existing) {
+      throw new ConflictException(
+        `A land record with parcel ID "${dto.parcelId}" already exists`,
+      );
+    }
+
+    const record = this.landRecordRepository.create(dto);
+    return this.landRecordRepository.save(record);
+  }
+
+  async findAll(filters: FilterLandRecordDto): Promise<LandRecord[]> {
+    const where: FindOptionsWhere<LandRecord> = {};
+
+    if (filters.status) {
+      where.status = filters.status;
+    }
+
+    if (filters.location) {
+      where.location = ILike(`%${filters.location}%`);
+    }
+
+    return this.landRecordRepository.find({
+      where,
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOne(id: string): Promise<LandRecord> {
+    const record = await this.landRecordRepository.findOne({ where: { id } });
+
+    if (!record) {
+      throw new NotFoundException(`Land record with ID "${id}" not found`);
+    }
+
+    return record;
+  }
+
+  async update(id: string, dto: UpdateLandRecordDto): Promise<LandRecord> {
+    const record = await this.findOne(id);
+
+    if (dto.parcelId && dto.parcelId !== record.parcelId) {
+      const conflict = await this.landRecordRepository.findOne({
+        where: { parcelId: dto.parcelId },
+      });
+
+      if (conflict) {
+        throw new ConflictException(
+          `A land record with parcel ID "${dto.parcelId}" already exists`,
+        );
+      }
+    }
+
+    Object.assign(record, dto);
+    return this.landRecordRepository.save(record);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.findOne(id);
+    await this.landRecordRepository.softDelete(id);
+  }
+}


### PR DESCRIPTION
…arcel management## Summary

  Introduces `LandRecordModule` — the central domain object in SMALDA. A land
  record represents a parcel of land with its ownership metadata, status
  lifecycle, and full CRUD surface via a REST API.

  ## Changes

  ### New module — `src/land-record/`

  - **`enums/land-record.enum.ts`** — `LandRecordStatus` enum: `ACTIVE`,
    `DISPUTED`, `TRANSFERRED`, `ARCHIVED`

  - **`entities/land-record.entity.ts`** — `LandRecord` TypeORM entity mapped
    to the `land_records` table. Fields: `id` (UUID PK), `parcelId` (unique),
    `location`, `area` (decimal 12,4), `ownerName`, `ownerContact` (nullable),
    `registrationDate` (date), `status` (enum), `createdAt`, `updatedAt`, and
    `deletedAt` (`@DeleteDateColumn`) for soft-delete support. Indexes on
    `parcelId` and `status`.

  - **`dto/create-land-record.dto.ts`** — Full `class-validator` + Swagger
    annotated DTO. `area` validated as a positive number; `registrationDate` as
    an ISO 8601 date string; `ownerContact` and `status` are optional.

  - **`dto/update-land-record.dto.ts`** — `PartialType(CreateLandRecordDto)`;
    all fields optional, Swagger decorators inherited.

  - **`dto/filter-land-record.dto.ts`** — Query filter DTO with optional
    `status` (enum) and `location` (partial, case-insensitive string match).

  - **`land-record.service.ts`** — Five service methods:

    | Method | Behaviour |
    |---|---|
    | `create` | Duplicate `parcelId` check before insert (`409`) |
    | `findAll` | Dynamic `where` with `ILike` for location filtering |
    | `findOne` | `404` on missing record |
    | `update` | Guards against `parcelId` collision on change |
    | `remove` | Soft-delete via `repository.softDelete` |

  - **`land-record.controller.ts`** — Full REST surface under
    `/api/land-records`:

    | Method | Endpoint | Description |
    |---|---|---|
    | `POST` | `/api/land-records` | Create a land record |
    | `GET` | `/api/land-records` | List all (filter by `status`, `location`) |
    | `GET` | `/api/land-records/:id` | Get one by UUID |
    | `PATCH` | `/api/land-records/:id` | Partial update |
    | `DELETE` | `/api/land-records/:id` | Soft-delete (returns `204`) |

  - **`land-record.module.ts`** — Registers `TypeOrmModule.forFeature`,
    controller, service; exports service for use by other modules.

  ### Modified

  - **`src/app.module.ts`** — Registers `LandRecordModule`
  
  closes #162 