### PR TITLE
  feat: implement RiskScoreModule for aggregate document risk scoring

### DIFF
--- a/backend/src/risk-score/interfaces/risk-score-result.interface.ts
+++ b/backend/src/risk-score/interfaces/risk-score-result.interface.ts
@@ -1,0 +1,17 @@
+export type RiskLevel = 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+export interface RiskScoreBreakdown {
+  low: number;
+  medium: number;
+  high: number;
+  critical: number;
+}
+
+export interface RiskScoreResult {
+  documentId: string;
+  score: number;
+  riskLevel: RiskLevel;
+  indicatorCount: number;
+  breakdown: RiskScoreBreakdown;
+  computedAt: Date;
+}

--- a/backend/src/risk-score/risk-score.controller.ts
+++ b/backend/src/risk-score/risk-score.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Param, ParseUUIDPipe } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { RiskScoreService } from './risk-score.service';
+import { RiskScoreResult } from './interfaces/risk-score-result.interface';
+
+@ApiTags('Risk Scores')
+@Controller('risk-scores')
+export class RiskScoreController {
+  constructor(private readonly riskScoreService: RiskScoreService) {}
+
+  @Get(':documentId')
+  @ApiOperation({
+    summary: 'Compute the aggregate risk score for a document',
+    description:
+      'Reads all unresolved risk indicators for the document and returns a ' +
+      'weighted score (0–100) along with a breakdown by severity.',
+  })
+  @ApiParam({ name: 'documentId', description: 'UUID of the document to score' })
+  @ApiResponse({
+    status: 200,
+    description: 'Computed risk score and breakdown',
+    schema: {
+      example: {
+        documentId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+        score: 52,
+        riskLevel: 'HIGH',
+        indicatorCount: 4,
+        breakdown: { low: 1, medium: 1, high: 1, critical: 1 },
+        computedAt: '2024-06-01T12:00:00.000Z',
+      },
+    },
+  })
+  computeScore(
+    @Param('documentId', ParseUUIDPipe) documentId: string,
+  ): Promise<RiskScoreResult> {
+    return this.riskScoreService.computeScore(documentId);
+  }
+}

--- a/backend/src/risk-score/risk-score.module.ts
+++ b/backend/src/risk-score/risk-score.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { RiskIndicatorModule } from '../risk-indicator/risk-indicator.module';
+import { RiskScoreController } from './risk-score.controller';
+import { RiskScoreService } from './risk-score.service';
+
+@Module({
+  imports: [RiskIndicatorModule],
+  controllers: [RiskScoreController],
+  providers: [RiskScoreService],
+  exports: [RiskScoreService],
+})
+export class RiskScoreModule {}

--- a/backend/src/risk-score/risk-score.service.ts
+++ b/backend/src/risk-score/risk-score.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@nestjs/common';
+import { RiskIndicatorService } from '../risk-indicator/risk-indicator.service';
+import { RiskIndicatorSeverity } from '../risk-indicator/enums/risk-indicator.enum';
+import {
+  RiskLevel,
+  RiskScoreResult,
+} from './interfaces/risk-score-result.interface';
+
+const WEIGHTS: Record<RiskIndicatorSeverity, number> = {
+  [RiskIndicatorSeverity.CRITICAL]: 30,
+  [RiskIndicatorSeverity.HIGH]: 15,
+  [RiskIndicatorSeverity.MEDIUM]: 7,
+  [RiskIndicatorSeverity.LOW]: 2,
+};
+
+const CRITICAL_CAP = 90;
+
+function resolveRiskLevel(score: number): RiskLevel {
+  if (score === 0) return 'NONE';
+  if (score <= 25) return 'LOW';
+  if (score <= 50) return 'MEDIUM';
+  if (score <= 75) return 'HIGH';
+  return 'CRITICAL';
+}
+
+@Injectable()
+export class RiskScoreService {
+  constructor(private readonly riskIndicatorService: RiskIndicatorService) {}
+
+  async computeScore(documentId: string): Promise<RiskScoreResult> {
+    const allIndicators =
+      await this.riskIndicatorService.findByDocument(documentId);
+
+    const unresolved = allIndicators.filter((i) => !i.isResolved);
+
+    const breakdown = { low: 0, medium: 0, high: 0, critical: 0 };
+
+    for (const indicator of unresolved) {
+      switch (indicator.severity) {
+        case RiskIndicatorSeverity.LOW:
+          breakdown.low++;
+          break;
+        case RiskIndicatorSeverity.MEDIUM:
+          breakdown.medium++;
+          break;
+        case RiskIndicatorSeverity.HIGH:
+          breakdown.high++;
+          break;
+        case RiskIndicatorSeverity.CRITICAL:
+          breakdown.critical++;
+          break;
+      }
+    }
+
+    const criticalScore = Math.min(
+      breakdown.critical * WEIGHTS[RiskIndicatorSeverity.CRITICAL],
+      CRITICAL_CAP,
+    );
+    const highScore = breakdown.high * WEIGHTS[RiskIndicatorSeverity.HIGH];
+    const mediumScore =
+      breakdown.medium * WEIGHTS[RiskIndicatorSeverity.MEDIUM];
+    const lowScore = breakdown.low * WEIGHTS[RiskIndicatorSeverity.LOW];
+
+    const raw = criticalScore + highScore + mediumScore + lowScore;
+    const score = Math.min(Math.max(raw, 0), 100);
+
+    return {
+      documentId,
+      score,
+      riskLevel: resolveRiskLevel(score),
+      indicatorCount: unresolved.length,
+      breakdown,
+      computedAt: new Date(),
+    };
+  }
+}


### PR DESCRIPTION
Adds a standalone `RiskScoreModule` that computes a weighted numerical risk
  score (0–100) for a document from its unresolved risk indicators, and exposes
  it via a single GET endpoint.

  ## Changes

  ### New module — `src/risk-score/`

  - **`interfaces/risk-score-result.interface.ts`** — `RiskLevel` union type,
    `RiskScoreBreakdown`, and `RiskScoreResult` interfaces

  - **`risk-score.service.ts`** — `computeScore(documentId)` applies a weighted
    formula to all unresolved indicators for the document:

    | Severity | Points | Cap |
    |---|---|---|
    | CRITICAL | 30 each | 90 |
    | HIGH | 15 each | — |
    | MEDIUM | 7 each | — |
    | LOW | 2 each | — |

    Final score is clamped to `[0, 100]`. Risk level is derived by threshold:
    `0 → NONE`, `1–25 → LOW`, `26–50 → MEDIUM`, `51–75 → HIGH`, `76–100 → CRITICAL`

  - **`risk-score.controller.ts`** — `GET /api/risk-scores/:documentId` returns
    the full `RiskScoreResult` with score, risk level, indicator count,
    per-severity breakdown, and computation timestamp

  - **`risk-score.module.ts`** — imports `RiskIndicatorModule` to reuse the
    exported `RiskIndicatorService`; no entity or repository needed

  ### Modified

  - **`src/app.module.ts`** — registers `RiskScoreModule`

  ## Design note

  `RiskScoreModule` depends on `RiskIndicatorModule` via its exported service
  rather than re-declaring the repository — keeping the module boundary clean
  and avoiding duplicate entity registrations.
  
  closes #167 