### PR TITLE
feat: implement DocumentSearchModule for full-text and filtered land …

### DIFF
--- a/backend/src/document-search/document-search.controller.ts
+++ b/backend/src/document-search/document-search.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { DocumentSearchService } from './document-search.service';
+import { SearchQueryDto } from './dto/search-query.dto';
+import { SearchResult } from './interfaces/search-result.interface';
+
+@ApiTags('Document Search')
+@Controller('search')
+export class DocumentSearchController {
+  constructor(private readonly documentSearchService: DocumentSearchService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Full-text and filtered search across land records',
+    description:
+      'Supports partial keyword matching on parcelId, ownerName, and location ' +
+      '(ILIKE), filtering by status, risk level, and registration date range. ' +
+      'Returns a paginated response.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated search results' })
+  search(@Query() query: SearchQueryDto): Promise<SearchResult> {
+    return this.documentSearchService.search(query);
+  }
+}

--- a/backend/src/document-search/document-search.module.ts
+++ b/backend/src/document-search/document-search.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LandRecord } from '../land-record/entities/land-record.entity';
+import { DocumentSearchService } from './document-search.service';
+import { DocumentSearchController } from './document-search.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([LandRecord])],
+  controllers: [DocumentSearchController],
+  providers: [DocumentSearchService],
+  exports: [DocumentSearchService],
+})
+export class DocumentSearchModule {}

--- a/backend/src/document-search/document-search.service.ts
+++ b/backend/src/document-search/document-search.service.ts
@@ -1,0 +1,97 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { LandRecord } from '../land-record/entities/land-record.entity';
+import { RiskIndicatorSeverity } from '../risk-indicator/enums/risk-indicator.enum';
+import { SearchQueryDto } from './dto/search-query.dto';
+import { RiskLevel } from './enums/risk-level.enum';
+import { SearchResult } from './interfaces/search-result.interface';
+
+// Maps each risk level to the set of severities that qualify a land record at
+// that level (highest unresolved indicator wins). Assumes risk_indicators rows
+// reference the land record UUID via their documentId column.
+const RISK_SEVERITY_MAP: Record<Exclude<RiskLevel, 'NONE'>, RiskIndicatorSeverity[]> = {
+  [RiskLevel.LOW]: [
+    RiskIndicatorSeverity.LOW,
+    RiskIndicatorSeverity.MEDIUM,
+    RiskIndicatorSeverity.HIGH,
+    RiskIndicatorSeverity.CRITICAL,
+  ],
+  [RiskLevel.MEDIUM]: [
+    RiskIndicatorSeverity.MEDIUM,
+    RiskIndicatorSeverity.HIGH,
+    RiskIndicatorSeverity.CRITICAL,
+  ],
+  [RiskLevel.HIGH]: [RiskIndicatorSeverity.HIGH, RiskIndicatorSeverity.CRITICAL],
+  [RiskLevel.CRITICAL]: [RiskIndicatorSeverity.CRITICAL],
+};
+
+@Injectable()
+export class DocumentSearchService {
+  constructor(
+    @InjectRepository(LandRecord)
+    private readonly landRecordRepository: Repository<LandRecord>,
+  ) {}
+
+  async search(query: SearchQueryDto): Promise<SearchResult> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+
+    const qb = this.landRecordRepository
+      .createQueryBuilder('lr')
+      .where('lr.deletedAt IS NULL');
+
+    if (query.keyword) {
+      qb.andWhere(
+        '(lr.parcelId ILIKE :kw OR lr.ownerName ILIKE :kw OR lr.location ILIKE :kw)',
+        { kw: `%${query.keyword}%` },
+      );
+    }
+
+    if (query.status) {
+      qb.andWhere('lr.status = :status', { status: query.status });
+    }
+
+    if (query.dateFrom) {
+      qb.andWhere('lr.registrationDate >= :dateFrom', { dateFrom: query.dateFrom });
+    }
+
+    if (query.dateTo) {
+      qb.andWhere('lr.registrationDate <= :dateTo', { dateTo: query.dateTo });
+    }
+
+    if (query.riskLevel === RiskLevel.NONE) {
+      // Records that have no unresolved indicators at all
+      qb.andWhere(
+        `lr.id NOT IN (
+          SELECT ri."documentId" FROM risk_indicators ri
+          WHERE ri."isResolved" = false
+        )`,
+      );
+    } else if (query.riskLevel) {
+      const severities = RISK_SEVERITY_MAP[query.riskLevel];
+      qb.andWhere(
+        `lr.id IN (
+          SELECT ri."documentId" FROM risk_indicators ri
+          WHERE ri."isResolved" = false
+            AND ri.severity IN (:...riskSeverities)
+        )`,
+        { riskSeverities: severities },
+      );
+    }
+
+    const [data, total] = await qb
+      .orderBy('lr.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+}

--- a/backend/src/document-search/dto/search-query.dto.ts
+++ b/backend/src/document-search/dto/search-query.dto.ts
@@ -1,0 +1,75 @@
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { LandRecordStatus } from '../../land-record/enums/land-record.enum';
+import { RiskLevel } from '../enums/risk-level.enum';
+
+export class SearchQueryDto {
+  @ApiPropertyOptional({
+    description:
+      'Partial case-insensitive match against parcelId, ownerName, and location',
+    example: 'Lagos',
+  })
+  @IsOptional()
+  @IsString()
+  keyword?: string;
+
+  @ApiPropertyOptional({
+    enum: LandRecordStatus,
+    description: 'Filter by land record status',
+    example: LandRecordStatus.ACTIVE,
+  })
+  @IsOptional()
+  @IsEnum(LandRecordStatus)
+  status?: LandRecordStatus;
+
+  @ApiPropertyOptional({
+    enum: RiskLevel,
+    description:
+      'Filter by computed risk level derived from unresolved risk indicators',
+    example: RiskLevel.HIGH,
+  })
+  @IsOptional()
+  @IsEnum(RiskLevel)
+  riskLevel?: RiskLevel;
+
+  @ApiPropertyOptional({
+    description: 'Include only records registered on or after this date (ISO 8601)',
+    example: '2023-01-01',
+  })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({
+    description: 'Include only records registered on or before this date (ISO 8601)',
+    example: '2024-12-31',
+  })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @ApiPropertyOptional({ description: 'Page number (1-based)', example: 1, default: 1 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Records per page (max 100)',
+    example: 20,
+    default: 20,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/backend/src/document-search/enums/risk-level.enum.ts
+++ b/backend/src/document-search/enums/risk-level.enum.ts
@@ -1,0 +1,7 @@
+export enum RiskLevel {
+  NONE = 'NONE',
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  CRITICAL = 'CRITICAL',
+}

--- a/backend/src/document-search/interfaces/search-result.interface.ts
+++ b/backend/src/document-search/interfaces/search-result.interface.ts
@@ -1,0 +1,9 @@
+import { LandRecord } from '../../land-record/entities/land-record.entity';
+
+export interface SearchResult {
+  data: LandRecord[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}


### PR DESCRIPTION
Description:
  Adds a standalone DocumentSearchModule that exposes a single GET /api/search endpoint for querying land records by keyword, status,   
  risk level, and registration date range.

  The DocumentSearchService builds a TypeORM QueryBuilder query that applies only the filters present in the request. Keyword search    
  uses ILIKE for case-insensitive partial matching across parcelId, ownerName, and location. The riskLevel filter uses a correlated     
  subquery against the risk_indicators table — NONE excludes records with any unresolved indicator, while LOW through CRITICAL use a    
  severity threshold map so higher levels subsume lower ones. Pagination is handled in a single getManyAndCount() call and the response 
  includes totalPages alongside the standard data, total, page, and limit fields.
  
  closes #170 