### PR TITLE
feat: add structured request/response logging with correlation IDs

### DIFF
--- a/backend/src/common/middleware/logger.middleware.ts
+++ b/backend/src/common/middleware/logger.middleware.ts
@@ -2,6 +2,7 @@
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import type { Logger } from 'winston';
 import { Request, Response, NextFunction } from 'express';
+import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class LoggerMiddleware implements NestMiddleware {
@@ -10,30 +11,33 @@ export class LoggerMiddleware implements NestMiddleware {
     private readonly logger: Logger,
   ) {}
 
-  use(req: Request, res: Response, next: NextFunction) {
+  use(req: Request & { correlationId?: string }, res: Response, next: NextFunction) {
+    const correlationId = uuidv4();
+    req.correlationId = correlationId;
+
     const start = Date.now();
-    const userAgent = req.headers['user-agent'] || 'unknown';
     const forwarded = req.headers['x-forwarded-for'];
     const ip = typeof forwarded === 'string'
       ? forwarded.split(',')[0].trim()
       : forwarded?.[0] ?? req.ip;
 
+    this.logger.info('http-request-incoming', {
+      correlationId,
+      method: req.method,
+      path: req.originalUrl || req.url,
+      ip,
+    });
+
     res.on('finish', () => {
-      const duration = Date.now() - start;
-      const payload: Record<string, unknown> = {
+      this.logger.info('http-request-finished', {
+        correlationId,
         method: req.method,
         path: req.originalUrl || req.url,
         status: res.statusCode,
-        duration_ms: duration,
-        user_agent: userAgent,
-        ip,
-      };
-
-      if (req.headers.authorization) {
-        payload.authorization = '[REDACTED]';
-      }
-
-      this.logger.info('http-request', payload);
+        duration_ms: Date.now() - start,
+        authorization: req.headers.authorization ? '[REDACTED]' : undefined,
+        cookie: req.headers.cookie ? '[REDACTED]' : undefined,
+      });
     });
 
     next();


### PR DESCRIPTION
Closes #281

- Generates a UUID `correlationId` per request, attached to `req`
- Logs incoming request (method, path, ip, correlationId)
- Logs response on finish (status, duration_ms, correlationId)
- Redacts `Authorization` and `Cookie` headers
