### PR TITLE
feat: implement BE-33, BE-35, BE-38, BE-40

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { QueueModule } from './queue/queue.module';
 import { RiskAssessmentModule } from './risk-assessment/risk-assessment.module';
 import { StellarModule } from './stellar/stellar.module';
 import { UsersModule } from './users/users.module';
+import { TasksModule } from './tasks/tasks.module';
 import { TransfersModule } from './transfers/transfers.module';
 import { VerificationModule } from './verification/verification.module';
 
@@ -52,6 +53,7 @@ import { VerificationModule } from './verification/verification.module';
     TransfersModule,
     MailModule,
     QueueModule,
+    TasksModule,
   ],
   controllers: [AppController],
   providers: [AppService, LoggerMiddleware],

--- a/backend/src/documents/documents.service.ts
+++ b/backend/src/documents/documents.service.ts
@@ -29,6 +29,14 @@ export class DocumentsService {
     return this.documentRepository.findOne({ where: { fileHash } });
   }
 
+  findByParcelId(parcelId: string, excludeId: string): Promise<Document | null> {
+    return this.documentRepository
+      .createQueryBuilder('document')
+      .where('document.id != :excludeId', { excludeId })
+      .andWhere('LOWER(document.title) LIKE :parcel', { parcel: `%${parcelId.toLowerCase()}%` })
+      .getOne();
+  }
+
   async updateStatus(id: string, status: DocumentStatus): Promise<Document | null> {
     await this.documentRepository.update(id, { status });
     return this.findById(id);

--- a/backend/src/risk-assessment/risk-assessment.service.spec.ts
+++ b/backend/src/risk-assessment/risk-assessment.service.spec.ts
@@ -1,0 +1,237 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+
+import { RiskAssessmentService, RiskFlag } from './risk-assessment.service';
+import { DocumentsService } from '../documents/documents.service';
+import { Document, DocumentStatus } from '../documents/entities/document.entity';
+
+const makeDoc = (overrides: Partial<Document> = {}): Document =>
+  ({
+    id: 'doc-1',
+    ownerId: 'owner-1',
+    title: 'Parcel 123 issued by Registry',
+    filePath: '/tmp/doc.pdf',
+    fileHash: 'abc123',
+    fileSize: 200_000,
+    mimeType: 'application/pdf',
+    status: DocumentStatus.PENDING,
+    riskScore: null,
+    riskFlags: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    owner: null,
+    ...overrides,
+  }) as Document;
+
+describe('RiskAssessmentService', () => {
+  let service: RiskAssessmentService;
+  let documentsService: jest.Mocked<DocumentsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RiskAssessmentService,
+        {
+          provide: DocumentsService,
+          useValue: {
+            findById: jest.fn(),
+            findByOwner: jest.fn().mockResolvedValue([]),
+            findByParcelId: jest.fn().mockResolvedValue(null),
+            updateRisk: jest.fn().mockResolvedValue(null),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<RiskAssessmentService>(RiskAssessmentService);
+    documentsService = module.get(DocumentsService);
+    jest.spyOn(service, 'extractTextContent').mockResolvedValue('');
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('assessDocument', () => {
+    it('throws NotFoundException when document is not found', async () => {
+      documentsService.findById.mockResolvedValue(null);
+      await expect(service.assessDocument('missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns score and flags and persists them', async () => {
+      const doc = makeDoc();
+      documentsService.findById.mockResolvedValue(doc);
+      jest
+        .spyOn(service, 'extractTextContent')
+        .mockResolvedValue('parcel no. ABC-001 signed authorized by land registry');
+
+      const result = await service.assessDocument(doc.id);
+      expect(result).toHaveProperty('score');
+      expect(result).toHaveProperty('flags');
+      expect(documentsService.updateRisk).toHaveBeenCalledWith(doc.id, result.score, result.flags);
+    });
+  });
+
+  describe('Flag detection — MISSING_PARCEL_ID', () => {
+    it('raised when no parcel pattern in text and no digits in title', async () => {
+      const doc = makeDoc({ title: 'no numbers here', mimeType: 'text/plain' });
+      documentsService.findById.mockResolvedValue(doc);
+      jest.spyOn(service, 'extractTextContent').mockResolvedValue('no parcel info');
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).toContain(RiskFlag.MISSING_PARCEL_ID);
+    });
+
+    it('not raised when parcel pattern found in text', async () => {
+      const doc = makeDoc({ title: 'issued document' });
+      documentsService.findById.mockResolvedValue(doc);
+      jest
+        .spyOn(service, 'extractTextContent')
+        .mockResolvedValue('parcel no. ABC-001 signed certified by land registry');
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).not.toContain(RiskFlag.MISSING_PARCEL_ID);
+    });
+  });
+
+  describe('Flag detection — OVERLAPPING_CLAIM', () => {
+    it('raised when duplicate parcel ID exists in DB', async () => {
+      const doc = makeDoc({ title: 'issued document' });
+      documentsService.findById.mockResolvedValue(doc);
+      jest
+        .spyOn(service, 'extractTextContent')
+        .mockResolvedValue('parcel no. ABC-001 signed authorized by land registry');
+      documentsService.findByParcelId.mockResolvedValue(makeDoc({ id: 'doc-2' }));
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).toContain(RiskFlag.OVERLAPPING_CLAIM);
+    });
+
+    it('not raised when no duplicate found', async () => {
+      const doc = makeDoc({ title: 'issued document' });
+      documentsService.findById.mockResolvedValue(doc);
+      jest
+        .spyOn(service, 'extractTextContent')
+        .mockResolvedValue('parcel no. ABC-001 signed certified by land registry');
+      documentsService.findByParcelId.mockResolvedValue(null);
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).not.toContain(RiskFlag.OVERLAPPING_CLAIM);
+    });
+  });
+
+  describe('Flag detection — FORGED_SIGNATURE_INDICATOR', () => {
+    it('raised when PDF has no signature keywords in text', async () => {
+      const doc = makeDoc({ title: 'Parcel 123 issued' });
+      documentsService.findById.mockResolvedValue(doc);
+      jest
+        .spyOn(service, 'extractTextContent')
+        .mockResolvedValue('parcel no. ABC-123 land registry document');
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).toContain(RiskFlag.FORGED_SIGNATURE_INDICATOR);
+    });
+
+    it('not raised when PDF contains a signature keyword', async () => {
+      const doc = makeDoc({ title: 'Doc 123 issued' });
+      documentsService.findById.mockResolvedValue(doc);
+      jest
+        .spyOn(service, 'extractTextContent')
+        .mockResolvedValue('parcel no. ABC-123 signed by land registry');
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).not.toContain(RiskFlag.FORGED_SIGNATURE_INDICATOR);
+    });
+  });
+
+  describe('Flag detection — EXPIRED_DOCUMENT', () => {
+    it('raised when title contains "expired"', async () => {
+      const doc = makeDoc({ title: 'expired document 123 issued' });
+      documentsService.findById.mockResolvedValue(doc);
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).toContain(RiskFlag.EXPIRED_DOCUMENT);
+    });
+
+    it('raised when extracted text contains "expired"', async () => {
+      const doc = makeDoc({ title: 'Parcel 123 issued' });
+      documentsService.findById.mockResolvedValue(doc);
+      jest
+        .spyOn(service, 'extractTextContent')
+        .mockResolvedValue('this document is expired signed certified');
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).toContain(RiskFlag.EXPIRED_DOCUMENT);
+    });
+  });
+
+  describe('Flag detection — INCOMPLETE_OWNERSHIP_CHAIN', () => {
+    it('raised when title is shorter than 12 characters', async () => {
+      const doc = makeDoc({ title: 'short' });
+      documentsService.findById.mockResolvedValue(doc);
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).toContain(RiskFlag.INCOMPLETE_OWNERSHIP_CHAIN);
+    });
+
+    it('raised for empty title', async () => {
+      const doc = makeDoc({ title: '' });
+      documentsService.findById.mockResolvedValue(doc);
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).toContain(RiskFlag.INCOMPLETE_OWNERSHIP_CHAIN);
+    });
+  });
+
+  describe('Flag detection — UNKNOWN_ISSUER', () => {
+    it('raised when no known issuer in text or title', async () => {
+      const doc = makeDoc({ title: 'Parcel 123 document' });
+      documentsService.findById.mockResolvedValue(doc);
+      jest
+        .spyOn(service, 'extractTextContent')
+        .mockResolvedValue('parcel no. ABC-001 signed document content');
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).toContain(RiskFlag.UNKNOWN_ISSUER);
+    });
+
+    it('not raised when known issuer found in text', async () => {
+      const doc = makeDoc({ title: 'Parcel 123 document' });
+      documentsService.findById.mockResolvedValue(doc);
+      jest
+        .spyOn(service, 'extractTextContent')
+        .mockResolvedValue('parcel no. ABC-001 signed land registry official');
+
+      const { flags } = await service.assessDocument(doc.id);
+      expect(flags).not.toContain(RiskFlag.UNKNOWN_ISSUER);
+    });
+  });
+
+  describe('calculateScore', () => {
+    it('returns 0 for no flags', () => {
+      expect(service.calculateScore([])).toBe(0);
+    });
+
+    it('returns correct weight for a single flag', () => {
+      expect(service.calculateScore([RiskFlag.MISSING_PARCEL_ID])).toBe(20);
+      expect(service.calculateScore([RiskFlag.FORGED_SIGNATURE_INDICATOR])).toBe(25);
+      expect(service.calculateScore([RiskFlag.OVERLAPPING_CLAIM])).toBe(20);
+      expect(service.calculateScore([RiskFlag.EXPIRED_DOCUMENT])).toBe(15);
+      expect(service.calculateScore([RiskFlag.INCOMPLETE_OWNERSHIP_CHAIN])).toBe(10);
+      expect(service.calculateScore([RiskFlag.UNKNOWN_ISSUER])).toBe(10);
+    });
+
+    it('sums weights for multiple flags', () => {
+      expect(
+        service.calculateScore([RiskFlag.MISSING_PARCEL_ID, RiskFlag.UNKNOWN_ISSUER]),
+      ).toBe(30);
+    });
+
+    it('caps score at 100 when all flags are triggered', () => {
+      const allFlags = Object.values(RiskFlag);
+      expect(service.calculateScore(allFlags)).toBe(100);
+    });
+
+    it('returns 0 for zero-byte file edge case (no flags triggered)', () => {
+      expect(service.calculateScore([])).toBe(0);
+    });
+  });
+});

--- a/backend/src/risk-assessment/risk-assessment.service.ts
+++ b/backend/src/risk-assessment/risk-assessment.service.ts
@@ -1,4 +1,6 @@
-﻿import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import * as fs from 'fs';
+import * as pdfParse from 'pdf-parse';
 
 import { DocumentsService } from '../documents/documents.service';
 import { Document } from '../documents/entities/document.entity';
@@ -26,8 +28,21 @@ const FLAG_WEIGHTS: Record<RiskFlag, number> = {
   [RiskFlag.UNKNOWN_ISSUER]: 10,
 };
 
+const KNOWN_ISSUERS = [
+  'land registry',
+  'ministry of lands',
+  'surveyor general',
+  'lands commission',
+  'deeds office',
+];
+const SIGNATURE_KEYWORDS = ['signed', 'signature', 'authorized by', 'notarized', 'certified'];
+const PARCEL_PATTERN = /\b(?:parcel|lot|plot|block)\s*(?:no\.?|number|#)?\s*[\w\d-]+/i;
+const PARCEL_ID_PATTERN = /\b[\w]{2,6}[-/]\d{3,10}\b/;
+
 @Injectable()
 export class RiskAssessmentService {
+  private readonly logger = new Logger(RiskAssessmentService.name);
+
   constructor(private readonly documentsService: DocumentsService) {}
 
   async assessDocument(documentId: string): Promise<RiskResult> {
@@ -44,42 +59,68 @@ export class RiskAssessmentService {
     return { score, flags };
   }
 
+  async extractTextContent(document: Document): Promise<string> {
+    if (document.mimeType !== 'application/pdf') return '';
+    try {
+      const buffer = fs.readFileSync(document.filePath);
+      const data = await pdfParse(buffer);
+      return data.text || '';
+    } catch {
+      return '';
+    }
+  }
+
   private async detectFlags(document: Document): Promise<RiskFlag[]> {
     const flags: RiskFlag[] = [];
 
-    if (!document.title || !/\d/.test(document.title)) {
+    const text = await this.extractTextContent(document);
+    const textLower = text.toLowerCase();
+
+    // MISSING_PARCEL_ID: no parcel pattern in text or digits in title
+    const hasParcelInText = PARCEL_PATTERN.test(text) || PARCEL_ID_PATTERN.test(text);
+    const hasParcelInTitle = /\d/.test(document.title ?? '');
+    if (!hasParcelInText && !hasParcelInTitle) {
       flags.push(RiskFlag.MISSING_PARCEL_ID);
     }
 
-    const ownerDocuments = await this.documentsService.findByOwner(document.ownerId);
-    if (ownerDocuments.some((doc) => doc.id !== document.id)) {
-      flags.push(RiskFlag.OVERLAPPING_CLAIM);
+    // OVERLAPPING_CLAIM: duplicate parcel ID found in DB
+    const parcelMatch = text.match(PARCEL_ID_PATTERN);
+    if (parcelMatch) {
+      const duplicate = await this.documentsService.findByParcelId(parcelMatch[0], document.id);
+      if (duplicate) flags.push(RiskFlag.OVERLAPPING_CLAIM);
+    } else {
+      const ownerDocuments = await this.documentsService.findByOwner(document.ownerId);
+      if (ownerDocuments.some((doc) => doc.id !== document.id)) {
+        flags.push(RiskFlag.OVERLAPPING_CLAIM);
+      }
     }
 
-    if (
-      document.mimeType === 'application/pdf' &&
-      document.fileSize !== undefined &&
-      document.fileSize < 50_000
-    ) {
-      flags.push(RiskFlag.FORGED_SIGNATURE_INDICATOR);
+    // FORGED_SIGNATURE_INDICATOR: content-integrity check (missing signature keywords)
+    if (document.mimeType === 'application/pdf') {
+      const hasSignature = SIGNATURE_KEYWORDS.some((kw) => textLower.includes(kw));
+      if (!hasSignature) flags.push(RiskFlag.FORGED_SIGNATURE_INDICATOR);
     }
 
-    if (document.title?.toLowerCase().includes('expired')) {
+    // EXPIRED_DOCUMENT
+    if (document.title?.toLowerCase().includes('expired') || textLower.includes('expired')) {
       flags.push(RiskFlag.EXPIRED_DOCUMENT);
     }
 
+    // INCOMPLETE_OWNERSHIP_CHAIN
     if (!document.title || document.title.trim().length < 12) {
       flags.push(RiskFlag.INCOMPLETE_OWNERSHIP_CHAIN);
     }
 
-    if (!document.title?.toLowerCase().includes('issued')) {
+    // UNKNOWN_ISSUER: check text for known issuer names or title fallback
+    const hasKnownIssuer = KNOWN_ISSUERS.some((issuer) => textLower.includes(issuer));
+    if (!hasKnownIssuer && !document.title?.toLowerCase().includes('issued')) {
       flags.push(RiskFlag.UNKNOWN_ISSUER);
     }
 
     return Array.from(new Set(flags));
   }
 
-  private calculateScore(flags: RiskFlag[]): number {
+  calculateScore(flags: RiskFlag[]): number {
     const rawScore = flags.reduce((total, flag) => total + (FLAG_WEIGHTS[flag] ?? 0), 0);
     return Math.min(100, Math.max(0, rawScore));
   }

--- a/backend/src/tasks/tasks.module.ts
+++ b/backend/src/tasks/tasks.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { Document } from '../documents/entities/document.entity';
+import { QueueModule } from '../queue/queue.module';
+import { TasksService } from './tasks.service';
+
+@Module({
+  imports: [ScheduleModule.forRoot(), TypeOrmModule.forFeature([Document]), QueueModule],
+  providers: [TasksService],
+})
+export class TasksModule {}

--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+
+import { Document, DocumentStatus } from '../documents/entities/document.entity';
+import { QueueService } from '../queue/queue.service';
+
+@Injectable()
+export class TasksService {
+  private readonly logger = new Logger(TasksService.name);
+
+  constructor(
+    @InjectRepository(Document)
+    private readonly documentRepository: Repository<Document>,
+    private readonly queueService: QueueService,
+  ) {}
+
+  @Cron('0 2 * * *')
+  async cleanUpStaleDocuments(): Promise<void> {
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const stale = await this.documentRepository.find({
+      where: [
+        { status: DocumentStatus.ANALYZING, updatedAt: LessThan(cutoff) },
+        { status: DocumentStatus.PENDING, updatedAt: LessThan(cutoff) },
+      ],
+    });
+
+    if (!stale.length) {
+      this.logger.log('Stale document cleanup: no stale documents found.');
+      return;
+    }
+
+    let requeued = 0;
+    for (const doc of stale) {
+      try {
+        await this.queueService.enqueueAnalyze(doc.id);
+        requeued++;
+      } catch {
+        await this.documentRepository.update(doc.id, {
+          status: DocumentStatus.REJECTED,
+          riskFlags: ['timeout'],
+        });
+      }
+    }
+
+    this.logger.log(
+      `Stale document cleanup: ${requeued}/${stale.length} re-enqueued, ${stale.length - requeued} marked REJECTED.`,
+    );
+  }
+}

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import * as jwt from 'jsonwebtoken';
+
+import { AppModule } from '../src/app.module';
+
+describe('Auth (e2e)', () => {
+  let app: INestApplication;
+  const testEmail = `e2e-${Date.now()}@example.com`;
+  const testPassword = 'StrongPass123!';
+  let refreshToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /api/auth/register', () => {
+    it('201 — registers a new user and returns access_token', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/auth/register')
+        .send({ email: testEmail, password: testPassword, fullName: 'E2E Test User' });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toHaveProperty('access_token');
+    });
+
+    it('409 — duplicate email returns conflict', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/auth/register')
+        .send({ email: testEmail, password: testPassword, fullName: 'E2E Test User' });
+
+      expect(res.status).toBe(409);
+    });
+
+    it('400 — invalid payload (missing email)', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/auth/register')
+        .send({ password: testPassword, fullName: 'E2E Test User' });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/auth/login', () => {
+    it('200 — returns access_token and refresh_token', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: testEmail, password: testPassword });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('access_token');
+      expect(res.body).toHaveProperty('refresh_token');
+      refreshToken = res.body.refresh_token;
+    });
+
+    it('401 — wrong password', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: testEmail, password: 'wrongpassword' });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('401 — unknown email', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ email: 'nobody@example.com', password: testPassword });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/auth/refresh', () => {
+    it('200 — returns new access_token with valid refresh token', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/auth/refresh')
+        .send({ refreshToken });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('access_token');
+    });
+
+    it('401 — expired refresh token', async () => {
+      const expiredToken = jwt.sign({ sub: 'user-id' }, 'secret', { expiresIn: -1 });
+      const res = await request(app.getHttpServer())
+        .post('/api/auth/refresh')
+        .send({ refreshToken: expiredToken });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('401 — tampered refresh token', async () => {
+      const tampered = refreshToken.slice(0, -5) + 'XXXXX';
+      const res = await request(app.getHttpServer())
+        .post('/api/auth/refresh')
+        .send({ refreshToken: tampered });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('Protected endpoints', () => {
+    it('401 — no token provided', async () => {
+      const res = await request(app.getHttpServer()).get('/api/documents');
+      expect(res.status).toBe(401);
+    });
+
+    it('401 — expired access token', async () => {
+      const expiredToken = jwt.sign(
+        { sub: 'user-id', email: 'x@x.com', role: 'user' },
+        'wrong-secret',
+        { expiresIn: -1 },
+      );
+      const res = await request(app.getHttpServer())
+        .get('/api/documents')
+        .set('Authorization', `Bearer ${expiredToken}`);
+
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
- BE-40: Replace file-size forgery heuristic with pdf-parse content analysis; detect parcel IDs, known issuers, and signature keywords from PDF text; detect duplicate parcel IDs via DB query (findByParcelId)
- BE-38: Add TasksModule with nightly @Cron job to re-enqueue or reject ANALYZING/PENDING documents stale for more than 24 hours
- BE-35: Add e2e test suite for auth flow covering register, login, refresh, and protected endpoint access (test/auth.e2e-spec.ts)
- BE-33: Add unit tests for all 6 RiskAssessmentService flag rules, score calculation, cap at 100, and edge cases (risk-assessment.service.spec.ts)

Closes #283
Closes #285
Closes #288
Closes #290