### PR TITLE
feat: add PaginationDto, RiskAssessmentResponseDto, VerificationResponseDto, and ThrottlerModule

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { CacheModule } from '@nestjs/cache-manager';
 import { WinstonModule } from 'nest-winston';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -29,6 +31,18 @@ import { validateConfig } from './config/env.validation';
       envFilePath: '.env',
       validate: validateConfig,
     }),
+    ThrottlerModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        throttlers: [
+          {
+            ttl: +(config.get('THROTTLE_TTL') ?? 60) * 1000,
+            limit: +(config.get('THROTTLE_LIMIT') ?? 10),
+          },
+        ],
+      }),
+    }),
     EventEmitterModule.forRoot(),
     CacheModule.registerAsync({
       isGlobal: true,
@@ -39,7 +53,7 @@ import { validateConfig } from './config/env.validation';
         host: config.get('REDIS_HOST') || '127.0.0.1',
         port: +(config.get('REDIS_PORT') || 6379),
         password: config.get('REDIS_PASSWORD') || undefined,
-        ttl: +(config.get('CACHE_TTL') || 300) * 1000, // ms
+        ttl: +(config.get('CACHE_TTL') || 300) * 1000,
       }),
     }),
     WinstonModule.forRootAsync({
@@ -76,7 +90,11 @@ import { validateConfig } from './config/env.validation';
     AuditModule,
   ],
   controllers: [AppController],
-  providers: [AppService, LoggerMiddleware],
+  providers: [
+    AppService,
+    LoggerMiddleware,
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -11,6 +11,7 @@ import {
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { AuthGuard } from '@nestjs/passport';
+import { Throttle } from '@nestjs/throttler';
 import { Request, Response } from 'express';
 import { Profile as GoogleProfile } from 'passport-google-oauth20';
 import { Profile as GithubProfile } from 'passport-github2';
@@ -29,6 +30,7 @@ export class AuthController {
   ) {}
 
   @Post('register')
+  @Throttle({ default: { ttl: 60_000, limit: 5 } })
   @ApiOperation({ summary: 'Register a new user' })
   @ApiResponse({ status: 201, description: 'User registered successfully' })
   @ApiResponse({ status: 409, description: 'Email already in use' })
@@ -37,6 +39,7 @@ export class AuthController {
   }
 
   @Post('login')
+  @Throttle({ default: { ttl: 60_000, limit: 5 } })
   @ApiOperation({ summary: 'Login with email and password' })
   @ApiResponse({ status: 200, description: 'Returns access and refresh tokens' })
   @ApiResponse({ status: 401, description: 'Invalid credentials' })

--- a/backend/src/common/dto/pagination.dto.ts
+++ b/backend/src/common/dto/pagination.dto.ts
@@ -1,0 +1,27 @@
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class PaginationDto {
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}
+
+export class PaginatedResponseDto<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -31,6 +31,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { User, UserRole } from '../users/entities/user.entity';
 import { QueueService } from '../queue/queue.service';
 import { VerificationService } from '../verification/verification.service';
+import { VerificationResponseDto } from '../verification/dto/verification-response.dto';
 import { AuditService } from '../audit/audit.service';
 import { AuditAction } from '../audit/entities/audit-log.entity';
 
@@ -159,9 +160,9 @@ export class DocumentsController {
   @Get(':id/verification')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'Get the latest verification record for a document' })
-  @ApiResponse({ status: 200, description: 'Verification record' })
+  @ApiResponse({ status: 200, type: VerificationResponseDto })
   @ApiResponse({ status: 404, description: 'Document or record not found' })
-  async getVerification(@Param('id') id: string) {
+  async getVerification(@Param('id') id: string): Promise<VerificationResponseDto> {
     const document = await this.documentsService.findById(id);
     if (!document) throw new NotFoundException('Document not found');
 

--- a/backend/src/documents/dto/query-documents.dto.ts
+++ b/backend/src/documents/dto/query-documents.dto.ts
@@ -1,8 +1,9 @@
 import { IsEnum, IsISO8601, IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 import { DocumentStatus } from '../entities/document.entity';
+import { PaginationDto } from '../../common/dto/pagination.dto';
 
-export class QueryDocumentsDto {
+export class QueryDocumentsDto extends PaginationDto {
   @IsOptional()
   @IsEnum(DocumentStatus)
   status?: DocumentStatus;
@@ -30,17 +31,4 @@ export class QueryDocumentsDto {
   @IsOptional()
   @IsString()
   search?: string;
-
-  @IsOptional()
-  @Type(() => Number)
-  @IsNumber()
-  @Min(1)
-  page?: number = 1;
-
-  @IsOptional()
-  @Type(() => Number)
-  @IsNumber()
-  @Min(1)
-  @Max(100)
-  limit?: number = 20;
 }

--- a/backend/src/risk-assessment/dto/risk-assessment-response.dto.ts
+++ b/backend/src/risk-assessment/dto/risk-assessment-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { RiskFlag } from '../risk-assessment.service';
+
+export class RiskAssessmentResponseDto {
+  @ApiProperty()
+  documentId: string;
+
+  @ApiProperty()
+  riskScore: number;
+
+  @ApiProperty({ enum: RiskFlag, isArray: true })
+  riskFlags: RiskFlag[];
+
+  @ApiProperty()
+  assessedAt: Date;
+}

--- a/backend/src/risk-assessment/risk-assessment.controller.ts
+++ b/backend/src/risk-assessment/risk-assessment.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Get, Param, UseGuards, UseInterceptors } from '@nestjs/common';
 import { CacheInterceptor, CacheKey, CacheTTL } from '@nestjs/cache-manager';
+import { ApiTags, ApiBearerAuth, ApiResponse } from '@nestjs/swagger';
 
 import { RiskAssessmentService } from './risk-assessment.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RiskAssessmentResponseDto } from './dto/risk-assessment-response.dto';
 
 @ApiTags('Documents')
 @ApiBearerAuth('JWT-auth')
@@ -14,8 +16,9 @@ export class RiskAssessmentController {
   @Get(':id/risk')
   @UseGuards(JwtAuthGuard)
   @CacheKey('document-risk')
-  @CacheTTL(300_000) // 5 minutes in ms
-  async getRisk(@Param('id') id: string) {
+  @CacheTTL(300_000)
+  @ApiResponse({ status: 200, type: RiskAssessmentResponseDto })
+  async getRisk(@Param('id') id: string): Promise<RiskAssessmentResponseDto> {
     return this.riskService.assessDocument(id);
   }
 }

--- a/backend/src/risk-assessment/risk-assessment.service.ts
+++ b/backend/src/risk-assessment/risk-assessment.service.ts
@@ -4,6 +4,7 @@ import { Cache } from 'cache-manager';
 
 import { DocumentsService } from '../documents/documents.service';
 import { Document } from '../documents/entities/document.entity';
+import { RiskAssessmentResponseDto } from './dto/risk-assessment-response.dto';
 
 export enum RiskFlag {
   MISSING_PARCEL_ID = 'MISSING_PARCEL_ID',
@@ -46,7 +47,7 @@ export class RiskAssessmentService {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
-  async assessDocument(documentId: string): Promise<RiskResult> {
+  async assessDocument(documentId: string): Promise<RiskAssessmentResponseDto> {
     const document = await this.documentsService.findById(documentId);
     if (!document) {
       throw new NotFoundException('Document not found');
@@ -56,10 +57,14 @@ export class RiskAssessmentService {
     const score = this.calculateScore(flags);
 
     await this.documentsService.updateRisk(documentId, score, flags);
-    // Invalidate cached risk result for this document
     await this.cacheManager.del(`document-risk:${documentId}`);
 
-    return { score, flags };
+    return {
+      documentId,
+      riskScore: score,
+      riskFlags: flags,
+      assessedAt: new Date(),
+    };
   }
 
   async extractTextContent(document: Document): Promise<string> {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { UsersService } from './users.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PaginationDto } from '../common/dto/pagination.dto';
+
+@ApiTags('Users')
+@ApiBearerAuth('JWT-auth')
+@Controller('users')
+@UseGuards(JwtAuthGuard)
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  list(@Query() pagination: PaginationDto) {
+    return this.usersService.findAll(pagination.page ?? 1, pagination.limit ?? 20);
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,10 +1,12 @@
-﻿import { Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
 import { User } from './entities/user.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
+  controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -25,6 +25,15 @@ export class UsersService {
     return this.findById(id);
   }
 
+  async findAll(page: number, limit: number): Promise<{ data: User[]; total: number; page: number; limit: number }> {
+    const [data, total] = await this.userRepository.findAndCount({
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return { data, total, page, limit };
+  }
+
   async softDelete(id: string): Promise<void> {
     await this.userRepository.softDelete(id);
   }

--- a/backend/src/verification/dto/verification-response.dto.ts
+++ b/backend/src/verification/dto/verification-response.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { VerificationStatus } from '../entities/verification-record.entity';
+
+export class VerificationResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  documentId: string;
+
+  @ApiProperty()
+  stellarTxHash: string;
+
+  @ApiProperty()
+  stellarLedger: number;
+
+  @ApiProperty({ nullable: true })
+  anchoredAt?: Date;
+
+  @ApiProperty({ enum: VerificationStatus })
+  status: VerificationStatus;
+}

--- a/backend/src/verification/verification.controller.ts
+++ b/backend/src/verification/verification.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { VerificationService } from './verification.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PaginationDto } from '../common/dto/pagination.dto';
+import { VerificationResponseDto } from './dto/verification-response.dto';
+
+@ApiTags('Verifications')
+@ApiBearerAuth('JWT-auth')
+@Controller('verifications')
+@UseGuards(JwtAuthGuard)
+export class VerificationController {
+  constructor(private readonly verificationService: VerificationService) {}
+
+  @Get()
+  @ApiResponse({ status: 200, type: VerificationResponseDto, isArray: true })
+  list(@Query() pagination: PaginationDto) {
+    return this.verificationService.findAll(pagination.page ?? 1, pagination.limit ?? 20);
+  }
+}

--- a/backend/src/verification/verification.module.ts
+++ b/backend/src/verification/verification.module.ts
@@ -1,10 +1,12 @@
-﻿import { Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { VerificationService } from './verification.service';
+import { VerificationController } from './verification.controller';
 import { VerificationRecord } from './entities/verification-record.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([VerificationRecord])],
+  controllers: [VerificationController],
   providers: [VerificationService],
   exports: [VerificationService],
 })

--- a/backend/src/verification/verification.service.ts
+++ b/backend/src/verification/verification.service.ts
@@ -63,12 +63,18 @@ export class VerificationService {
   }
 
   async hardDeleteByDocument(documentId: string): Promise<void> {
-    // Find all verification records for this document (including soft-deleted ones)
     const records = await this.findByDocumentIncludingDeleted(documentId);
-    
-    // Hard delete each record
     for (const record of records) {
       await this.hardDelete(record.id);
     }
+  }
+
+  async findAll(page: number, limit: number): Promise<{ data: VerificationRecord[]; total: number; page: number; limit: number }> {
+    const [data, total] = await this.verificationRepository.findAndCount({
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return { data, total, page, limit };
   }
 }


### PR DESCRIPTION
## Summary

Resolves four backend issues in a single PR.

### Changes

**#263 - Shared PaginationDto**
- Created `src/common/dto/pagination.dto.ts` with `PaginationDto` (`page`, `limit`) and generic `PaginatedResponseDto`
- `QueryDocumentsDto` now extends `PaginationDto` (removes duplicate pagination fields)
- Added paginated `GET /users` endpoint via new `UsersController`
- Added paginated `GET /verifications` endpoint via new `VerificationController`
- All list responses include `data`, `total`, `page`, `limit`

**#264 - RiskAssessmentResponseDto**
- Created `src/risk-assessment/dto/risk-assessment-response.dto.ts` with `@ApiProperty()` decorators
- `assessDocument()` now returns typed `RiskAssessmentResponseDto` (`documentId`, `riskScore`, `riskFlags`, `assessedAt`)
- Applied to `GET /documents/:id/risk` controller with `@ApiResponse` type

**#265 - VerificationResponseDto**
- Created `src/verification/dto/verification-response.dto.ts` with `@ApiProperty()` decorators
- `status` typed as `VerificationStatus` enum
- Applied to `GET /documents/:id/verification` and `GET /verifications`

**#266 - ThrottlerModule**
- Imported `ThrottlerModule.forRootAsync()` in `AppModule` using `THROTTLE_TTL` and `THROTTLE_LIMIT` env vars
- Applied `ThrottlerGuard` globally via `APP_GUARD` provider
- Applied stricter `@Throttle({ default: { ttl: 60_000, limit: 5 } })` on `POST /auth/login` and `POST /auth/register`

Closes #263
Closes #264
Closes #265
Closes #266