### PR TITLE
feat: Navigation, NotificationCenter, ShareModal, DocumentFilters (FE-25–28)

### DIFF
--- a/frontend/cmmty/components/DocumentFilters/DocumentFilters.test.tsx
+++ b/frontend/cmmty/components/DocumentFilters/DocumentFilters.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import DocumentFilters from "./DocumentFilters";
+
+jest.useFakeTimers();
+
+describe("DocumentFilters – debounce", () => {
+  it("does not call onChange immediately on search input", () => {
+    const onChange = jest.fn();
+    render(<DocumentFilters onChange={onChange} debounceMs={300} />);
+    fireEvent.change(screen.getByLabelText(/search documents/i), { target: { value: "parcel" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("calls onChange after debounce delay", () => {
+    const onChange = jest.fn();
+    render(<DocumentFilters onChange={onChange} debounceMs={300} />);
+    fireEvent.change(screen.getByLabelText(/search documents/i), { target: { value: "parcel" } });
+    act(() => jest.advanceTimersByTime(300));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: "parcel" }));
+  });
+
+  it("debounces multiple rapid inputs into one call", () => {
+    const onChange = jest.fn();
+    render(<DocumentFilters onChange={onChange} debounceMs={300} />);
+    const input = screen.getByLabelText(/search documents/i);
+    fireEvent.change(input, { target: { value: "a" } });
+    fireEvent.change(input, { target: { value: "ab" } });
+    fireEvent.change(input, { target: { value: "abc" } });
+    act(() => jest.advanceTimersByTime(300));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: "abc" }));
+  });
+});
+
+describe("DocumentFilters – filter state", () => {
+  it("shows active filter count badge when filters are set", () => {
+    render(<DocumentFilters />);
+    fireEvent.change(screen.getByLabelText(/filter by status/i), { target: { value: "VERIFIED" } });
+    expect(screen.getByLabelText("1 active filters")).toBeInTheDocument();
+  });
+
+  it("clears all filters on Clear all click", () => {
+    const onChange = jest.fn();
+    render(<DocumentFilters onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText(/filter by status/i), { target: { value: "FLAGGED" } });
+    fireEvent.change(screen.getByLabelText(/search documents/i), { target: { value: "test" } });
+    fireEvent.click(screen.getByRole("button", { name: /clear all filters/i }));
+    expect(onChange).toHaveBeenLastCalledWith({ search: "", status: "ALL", dateFrom: "", dateTo: "" });
+    expect(screen.queryByLabelText(/active filters/i)).toBeNull();
+  });
+
+  it("does not show badge when no filters active", () => {
+    render(<DocumentFilters />);
+    expect(screen.queryByLabelText(/active filters/i)).toBeNull();
+  });
+});

--- a/frontend/cmmty/components/DocumentFilters/DocumentFilters.tsx
+++ b/frontend/cmmty/components/DocumentFilters/DocumentFilters.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Search, X } from "lucide-react";
+
+export type DocumentStatus = "ALL" | "PENDING" | "ANALYZING" | "VERIFIED" | "FLAGGED" | "REJECTED";
+
+export interface FilterState {
+  search: string;
+  status: DocumentStatus;
+  dateFrom: string;
+  dateTo: string;
+}
+
+interface DocumentFiltersProps {
+  onChange?: (filters: FilterState) => void;
+  debounceMs?: number;
+}
+
+const STATUS_OPTIONS: DocumentStatus[] = ["ALL", "PENDING", "ANALYZING", "VERIFIED", "FLAGGED", "REJECTED"];
+
+const EMPTY: FilterState = { search: "", status: "ALL", dateFrom: "", dateTo: "" };
+
+export default function DocumentFilters({ onChange, debounceMs = 300 }: DocumentFiltersProps) {
+  const [filters, setFilters] = useState<FilterState>(EMPTY);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const activeCount = [
+    filters.search !== "",
+    filters.status !== "ALL",
+    filters.dateFrom !== "",
+    filters.dateTo !== "",
+  ].filter(Boolean).length;
+
+  const update = (patch: Partial<FilterState>) => {
+    setFilters((prev) => {
+      const next = { ...prev, ...patch };
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => onChange?.(next), debounceMs);
+      return next;
+    });
+  };
+
+  // Flush on unmount
+  useEffect(() => () => { if (debounceRef.current) clearTimeout(debounceRef.current); }, []);
+
+  const clearAll = () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setFilters(EMPTY);
+    onChange?.(EMPTY);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 p-3 bg-white border border-gray-200 rounded-lg">
+      {/* Search input */}
+      <div className="relative flex-1 min-w-48">
+        <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+        <input
+          type="text"
+          value={filters.search}
+          onChange={(e) => update({ search: e.target.value })}
+          placeholder="Search documents…"
+          className="w-full pl-8 pr-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          aria-label="Search documents"
+        />
+      </div>
+
+      {/* Status dropdown */}
+      <select
+        value={filters.status}
+        onChange={(e) => update({ status: e.target.value as DocumentStatus })}
+        className="py-2 px-3 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 bg-white"
+        aria-label="Filter by status"
+      >
+        {STATUS_OPTIONS.map((s) => (
+          <option key={s} value={s}>
+            {s === "ALL" ? "All Statuses" : s}
+          </option>
+        ))}
+      </select>
+
+      {/* Date range */}
+      <input
+        type="date"
+        value={filters.dateFrom}
+        onChange={(e) => update({ dateFrom: e.target.value })}
+        className="py-2 px-3 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        aria-label="From date"
+      />
+      <input
+        type="date"
+        value={filters.dateTo}
+        onChange={(e) => update({ dateTo: e.target.value })}
+        className="py-2 px-3 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        aria-label="To date"
+      />
+
+      {/* Active filter badge + clear */}
+      {activeCount > 0 && (
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-indigo-600 text-white text-[11px] font-bold" aria-label={`${activeCount} active filters`}>
+            {activeCount}
+          </span>
+          <button
+            onClick={clearAll}
+            className="flex items-center gap-1 text-sm text-gray-500 hover:text-red-500"
+            aria-label="Clear all filters"
+          >
+            <X size={14} />
+            Clear all
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/cmmty/components/DocumentFilters/index.ts
+++ b/frontend/cmmty/components/DocumentFilters/index.ts
@@ -1,0 +1,2 @@
+export { default as DocumentFilters } from "./DocumentFilters";
+export type { FilterState, DocumentStatus } from "./DocumentFilters";

--- a/frontend/cmmty/components/Navigation/Header.tsx
+++ b/frontend/cmmty/components/Navigation/Header.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu, X, Bell, LayoutDashboard, FileText, Upload, Map, Settings, ShieldCheck } from "lucide-react";
+
+interface HeaderProps {
+  onNotificationClick?: () => void;
+  unreadCount?: number;
+  isAdmin?: boolean;
+}
+
+const navLinks = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/documents", label: "Documents", icon: FileText },
+  { href: "/upload", label: "Upload", icon: Upload },
+  { href: "/map", label: "Map", icon: Map },
+  { href: "/settings", label: "Settings", icon: Settings },
+];
+
+const adminLink = { href: "/admin", label: "Admin", icon: ShieldCheck };
+
+export default function Header({ onNotificationClick, unreadCount = 0, isAdmin = false }: HeaderProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const pathname = usePathname();
+  const links = isAdmin ? [...navLinks, adminLink] : navLinks;
+
+  return (
+    <header className="md:hidden bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
+      <span className="text-lg font-bold text-indigo-600">SMALDA</span>
+
+      <div className="flex items-center gap-3">
+        {/* Notification bell */}
+        <button
+          onClick={onNotificationClick}
+          className="relative p-1 text-gray-500 hover:text-gray-700"
+          aria-label="Notifications"
+        >
+          <Bell size={20} />
+          {unreadCount > 0 && (
+            <span className="absolute -top-1 -right-1 bg-red-500 text-white text-[10px] font-bold rounded-full w-4 h-4 flex items-center justify-center">
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </span>
+          )}
+        </button>
+
+        {/* Hamburger */}
+        <button
+          onClick={() => setMenuOpen((o) => !o)}
+          className="p-1 text-gray-500 hover:text-gray-700"
+          aria-label={menuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={menuOpen}
+        >
+          {menuOpen ? <X size={22} /> : <Menu size={22} />}
+        </button>
+      </div>
+
+      {/* Mobile nav drawer */}
+      {menuOpen && (
+        <nav className="absolute top-14 left-0 right-0 bg-white border-b border-gray-200 z-50 py-2 shadow-md">
+          {links.map(({ href, label, icon: Icon }) => {
+            const active = pathname === href || pathname.startsWith(href + "/");
+            return (
+              <Link
+                key={href}
+                href={href}
+                onClick={() => setMenuOpen(false)}
+                className={`flex items-center gap-3 px-5 py-3 text-sm font-medium ${
+                  active ? "text-indigo-700 bg-indigo-50" : "text-gray-700 hover:bg-gray-50"
+                }`}
+                aria-current={active ? "page" : undefined}
+              >
+                <Icon size={18} />
+                {label}
+              </Link>
+            );
+          })}
+        </nav>
+      )}
+    </header>
+  );
+}

--- a/frontend/cmmty/components/Navigation/Navigation.test.tsx
+++ b/frontend/cmmty/components/Navigation/Navigation.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { usePathname } from "next/navigation";
+import Sidebar from "./Sidebar";
+import Header from "./Header";
+
+jest.mock("next/navigation", () => ({ usePathname: jest.fn() }));
+jest.mock("next/link", () => ({ __esModule: true, default: ({ href, children, ...props }: any) => <a href={href} {...props}>{children}</a> }));
+
+const mockPathname = usePathname as jest.Mock;
+
+describe("Sidebar – active link detection", () => {
+  it("marks the current route as active", () => {
+    mockPathname.mockReturnValue("/documents");
+    render(<Sidebar />);
+    const link = screen.getByRole("link", { name: /documents/i });
+    expect(link).toHaveAttribute("aria-current", "page");
+  });
+
+  it("does not mark other routes as active", () => {
+    mockPathname.mockReturnValue("/documents");
+    render(<Sidebar />);
+    const dashLink = screen.getByRole("link", { name: /dashboard/i });
+    expect(dashLink).not.toHaveAttribute("aria-current", "page");
+  });
+
+  it("hides Admin link when isAdmin is false", () => {
+    mockPathname.mockReturnValue("/dashboard");
+    render(<Sidebar isAdmin={false} />);
+    expect(screen.queryByRole("link", { name: /admin/i })).toBeNull();
+  });
+
+  it("shows Admin link when isAdmin is true", () => {
+    mockPathname.mockReturnValue("/dashboard");
+    render(<Sidebar isAdmin={true} />);
+    expect(screen.getByRole("link", { name: /admin/i })).toBeInTheDocument();
+  });
+
+  it("collapses sidebar on toggle", () => {
+    mockPathname.mockReturnValue("/dashboard");
+    render(<Sidebar />);
+    const btn = screen.getByRole("button", { name: /collapse/i });
+    fireEvent.click(btn);
+    expect(screen.getByRole("button", { name: /expand/i })).toBeInTheDocument();
+  });
+});
+
+describe("Header – active link detection", () => {
+  it("marks the current route as active in mobile menu", () => {
+    mockPathname.mockReturnValue("/upload");
+    render(<Header />);
+    fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
+    const link = screen.getByRole("link", { name: /upload/i });
+    expect(link).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/frontend/cmmty/components/Navigation/Sidebar.tsx
+++ b/frontend/cmmty/components/Navigation/Sidebar.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import {
+  LayoutDashboard,
+  FileText,
+  Upload,
+  Map,
+  Settings,
+  ShieldCheck,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+
+interface SidebarProps {
+  userName?: string;
+  userInitials?: string;
+  avatarUrl?: string;
+  isAdmin?: boolean;
+}
+
+const navLinks = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/documents", label: "Documents", icon: FileText },
+  { href: "/upload", label: "Upload", icon: Upload },
+  { href: "/map", label: "Map", icon: Map },
+  { href: "/settings", label: "Settings", icon: Settings },
+];
+
+const adminLink = { href: "/admin", label: "Admin", icon: ShieldCheck };
+
+export default function Sidebar({
+  userName = "User",
+  userInitials = "U",
+  avatarUrl,
+  isAdmin = false,
+}: SidebarProps) {
+  const pathname = usePathname();
+  const [collapsed, setCollapsed] = useState(false);
+
+  const links = isAdmin ? [...navLinks, adminLink] : navLinks;
+
+  return (
+    <aside
+      className={`hidden md:flex flex-col h-screen bg-white border-r border-gray-200 transition-all duration-200 ${
+        collapsed ? "w-16" : "w-56"
+      }`}
+    >
+      {/* Logo */}
+      <div className="flex items-center justify-between px-4 py-4 border-b border-gray-100">
+        {!collapsed && (
+          <span className="text-lg font-bold text-indigo-600">SMALDA</span>
+        )}
+        <button
+          onClick={() => setCollapsed((c) => !c)}
+          className="p-1 rounded hover:bg-gray-100 text-gray-500"
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        >
+          {collapsed ? <ChevronRight size={18} /> : <ChevronLeft size={18} />}
+        </button>
+      </div>
+
+      {/* Nav links */}
+      <nav className="flex-1 py-4 space-y-1 overflow-y-auto">
+        {links.map(({ href, label, icon: Icon }) => {
+          const active = pathname === href || pathname.startsWith(href + "/");
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`flex items-center gap-3 px-4 py-2 text-sm font-medium rounded-md mx-2 transition-colors ${
+                active
+                  ? "bg-indigo-50 text-indigo-700"
+                  : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+              }`}
+              aria-current={active ? "page" : undefined}
+            >
+              <Icon size={18} className="shrink-0" />
+              {!collapsed && <span>{label}</span>}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* User footer */}
+      <div className="border-t border-gray-100 px-4 py-3 flex items-center gap-3">
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt={userName}
+            className="w-8 h-8 rounded-full object-cover shrink-0"
+          />
+        ) : (
+          <div className="w-8 h-8 rounded-full bg-indigo-600 text-white flex items-center justify-center text-xs font-semibold shrink-0">
+            {userInitials}
+          </div>
+        )}
+        {!collapsed && (
+          <span className="text-sm text-gray-700 truncate">{userName}</span>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/cmmty/components/Navigation/index.ts
+++ b/frontend/cmmty/components/Navigation/index.ts
@@ -1,0 +1,2 @@
+export { default as Sidebar } from "./Sidebar";
+export { default as Header } from "./Header";

--- a/frontend/cmmty/components/NotificationCenter/NotificationCenter.test.tsx
+++ b/frontend/cmmty/components/NotificationCenter/NotificationCenter.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import NotificationCenter, { Notification } from "./NotificationCenter";
+
+const makeNotifications = (overrides: Partial<Notification>[] = []): Notification[] =>
+  overrides.map((o, i) => ({
+    id: String(i + 1),
+    type: "info",
+    title: `Notification ${i + 1}`,
+    body: "Body text",
+    timestamp: new Date(),
+    read: false,
+    ...o,
+  }));
+
+const openDropdown = () => fireEvent.click(screen.getByRole("button", { name: /notifications/i }));
+
+describe("NotificationCenter", () => {
+  it("shows unread count badge", () => {
+    render(<NotificationCenter initialNotifications={makeNotifications([{}, {}])} />);
+    expect(screen.getByLabelText("2 unread notifications")).toBeInTheDocument();
+  });
+
+  it("shows no badge when all read", () => {
+    render(<NotificationCenter initialNotifications={makeNotifications([{ read: true }])} />);
+    expect(screen.queryByLabelText(/unread notifications/i)).toBeNull();
+  });
+
+  it("shows empty state when no notifications", () => {
+    render(<NotificationCenter initialNotifications={[]} />);
+    openDropdown();
+    expect(screen.getByText(/no notifications/i)).toBeInTheDocument();
+  });
+
+  it("marks individual notification as read on click", () => {
+    render(<NotificationCenter initialNotifications={makeNotifications([{}, {}])} />);
+    openDropdown();
+    fireEvent.click(screen.getByText("Notification 1"));
+    expect(screen.getByLabelText("1 unread notifications")).toBeInTheDocument();
+  });
+
+  it("marks all notifications as read", () => {
+    render(<NotificationCenter initialNotifications={makeNotifications([{}, {}, {}])} />);
+    openDropdown();
+    fireEvent.click(screen.getByRole("button", { name: /mark all as read/i }));
+    expect(screen.queryByLabelText(/unread notifications/i)).toBeNull();
+  });
+});

--- a/frontend/cmmty/components/NotificationCenter/NotificationCenter.tsx
+++ b/frontend/cmmty/components/NotificationCenter/NotificationCenter.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { Bell, CheckCheck, Info, AlertTriangle, CheckCircle, XCircle } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+
+export interface Notification {
+  id: string;
+  type: "info" | "success" | "warning" | "error";
+  title: string;
+  body: string;
+  timestamp: Date;
+  read: boolean;
+}
+
+interface NotificationCenterProps {
+  initialNotifications?: Notification[];
+}
+
+const typeIcon = {
+  info: <Info size={16} className="text-blue-500" />,
+  success: <CheckCircle size={16} className="text-green-500" />,
+  warning: <AlertTriangle size={16} className="text-yellow-500" />,
+  error: <XCircle size={16} className="text-red-500" />,
+};
+
+export default function NotificationCenter({ initialNotifications = [] }: NotificationCenterProps) {
+  const [open, setOpen] = useState(false);
+  const [notifications, setNotifications] = useState<Notification[]>(initialNotifications);
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  const markAsRead = (id: string) =>
+    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
+
+  const markAllAsRead = () =>
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+
+  return (
+    <div className="relative">
+      {/* Bell trigger */}
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="relative p-2 text-gray-500 hover:text-gray-700 rounded-full hover:bg-gray-100"
+        aria-label="Notifications"
+        aria-expanded={open}
+      >
+        <Bell size={20} />
+        {unreadCount > 0 && (
+          <span
+            className="absolute -top-0.5 -right-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full w-4 h-4 flex items-center justify-center"
+            aria-label={`${unreadCount} unread notifications`}
+          >
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Dropdown */}
+      {open && (
+        <div className="absolute right-0 mt-2 w-80 bg-white rounded-lg shadow-lg border border-gray-200 z-50">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+            <span className="text-sm font-semibold text-gray-800">Notifications</span>
+            {unreadCount > 0 && (
+              <button
+                onClick={markAllAsRead}
+                className="flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800"
+                aria-label="Mark all as read"
+              >
+                <CheckCheck size={14} />
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          <ul className="max-h-80 overflow-y-auto divide-y divide-gray-50">
+            {notifications.length === 0 ? (
+              <li className="px-4 py-8 text-center text-sm text-gray-400">No notifications</li>
+            ) : (
+              notifications.map((n) => (
+                <li
+                  key={n.id}
+                  onClick={() => markAsRead(n.id)}
+                  className={`flex gap-3 px-4 py-3 cursor-pointer hover:bg-gray-50 transition-colors ${
+                    !n.read ? "bg-indigo-50/40" : ""
+                  }`}
+                >
+                  <span className="mt-0.5 shrink-0">{typeIcon[n.type]}</span>
+                  <div className="flex-1 min-w-0">
+                    <p className={`text-sm font-medium truncate ${!n.read ? "text-gray-900" : "text-gray-600"}`}>
+                      {n.title}
+                    </p>
+                    <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">{n.body}</p>
+                    <p className="text-[11px] text-gray-400 mt-1">
+                      {formatDistanceToNow(n.timestamp, { addSuffix: true })}
+                    </p>
+                  </div>
+                  {!n.read && (
+                    <span className="w-2 h-2 rounded-full bg-indigo-500 mt-1.5 shrink-0" aria-hidden="true" />
+                  )}
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/cmmty/components/NotificationCenter/index.ts
+++ b/frontend/cmmty/components/NotificationCenter/index.ts
@@ -1,0 +1,2 @@
+export { default as NotificationCenter } from "./NotificationCenter";
+export type { Notification } from "./NotificationCenter";

--- a/frontend/cmmty/components/ShareModal/ShareModal.test.tsx
+++ b/frontend/cmmty/components/ShareModal/ShareModal.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ShareModal from "./ShareModal";
+
+const noop = () => {};
+
+describe("ShareModal – email validation", () => {
+  it("shows error for invalid email", async () => {
+    render(<ShareModal documentId="doc1" onClose={noop} />);
+    fireEvent.change(screen.getByLabelText(/recipient email/i), { target: { value: "not-an-email" } });
+    fireEvent.click(screen.getByRole("button", { name: /^share$/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/valid email/i);
+  });
+
+  it("does not show error for valid email", async () => {
+    const onShare = jest.fn().mockResolvedValue(undefined);
+    render(<ShareModal documentId="doc1" onShare={onShare} onClose={noop} />);
+    fireEvent.change(screen.getByLabelText(/recipient email/i), { target: { value: "user@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /^share$/i }));
+    await waitFor(() => expect(onShare).toHaveBeenCalledWith("doc1", "user@example.com"));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("ShareModal – share submission", () => {
+  it("adds email to shared list on success", async () => {
+    const onShare = jest.fn().mockResolvedValue(undefined);
+    render(<ShareModal documentId="doc1" onShare={onShare} onClose={noop} />);
+    fireEvent.change(screen.getByLabelText(/recipient email/i), { target: { value: "new@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /^share$/i }));
+    expect(await screen.findByText("new@example.com")).toBeInTheDocument();
+  });
+
+  it("shows error message on API failure", async () => {
+    const onShare = jest.fn().mockRejectedValue(new Error("fail"));
+    render(<ShareModal documentId="doc1" onShare={onShare} onClose={noop} />);
+    fireEvent.change(screen.getByLabelText(/recipient email/i), { target: { value: "fail@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /^share$/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/failed to share/i);
+  });
+
+  it("calls onRevoke and removes entry", async () => {
+    const onRevoke = jest.fn().mockResolvedValue(undefined);
+    render(
+      <ShareModal
+        documentId="doc1"
+        existingShares={[{ id: "s1", email: "shared@example.com" }]}
+        onRevoke={onRevoke}
+        onClose={noop}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /revoke access for shared@example.com/i }));
+    await waitFor(() => expect(onRevoke).toHaveBeenCalledWith("doc1", "s1"));
+    expect(screen.queryByText("shared@example.com")).toBeNull();
+  });
+});

--- a/frontend/cmmty/components/ShareModal/ShareModal.tsx
+++ b/frontend/cmmty/components/ShareModal/ShareModal.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import { X, Loader2, Trash2 } from "lucide-react";
+
+export interface ShareEntry {
+  id: string;
+  email: string;
+}
+
+interface ShareModalProps {
+  documentId: string;
+  existingShares?: ShareEntry[];
+  onShare?: (documentId: string, email: string) => Promise<void>;
+  onRevoke?: (documentId: string, shareId: string) => Promise<void>;
+  onClose: () => void;
+}
+
+const isValidEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
+export default function ShareModal({
+  documentId,
+  existingShares = [],
+  onShare,
+  onRevoke,
+  onClose,
+}: ShareModalProps) {
+  const [email, setEmail] = useState("");
+  const [emailError, setEmailError] = useState("");
+  const [shares, setShares] = useState<ShareEntry[]>(existingShares);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitError("");
+
+    if (!isValidEmail(email)) {
+      setEmailError("Enter a valid email address.");
+      return;
+    }
+    setEmailError("");
+
+    try {
+      setSubmitting(true);
+      await onShare?.(documentId, email);
+      setShares((prev) => [...prev, { id: Date.now().toString(), email }]);
+      setEmail("");
+    } catch {
+      setSubmitError("Failed to share document. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRevoke = async (shareId: string) => {
+    try {
+      setRevokingId(shareId);
+      await onRevoke?.(documentId, shareId);
+      setShares((prev) => prev.filter((s) => s.id !== shareId));
+    } finally {
+      setRevokingId(null);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="share-modal-title"
+    >
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-md mx-4">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+          <h2 id="share-modal-title" className="text-base font-semibold text-gray-800">
+            Share Document
+          </h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600" aria-label="Close">
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Share form */}
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-3">
+          <label htmlFor="share-email" className="block text-sm font-medium text-gray-700">
+            Recipient email
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="share-email"
+              type="email"
+              value={email}
+              onChange={(e) => { setEmail(e.target.value); setEmailError(""); }}
+              placeholder="user@example.com"
+              className={`flex-1 border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                emailError ? "border-red-400" : "border-gray-300"
+              }`}
+              aria-describedby={emailError ? "email-error" : undefined}
+              disabled={submitting}
+            />
+            <button
+              type="submit"
+              disabled={submitting}
+              className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-md hover:bg-indigo-700 disabled:opacity-60 flex items-center gap-1"
+            >
+              {submitting && <Loader2 size={14} className="animate-spin" />}
+              Share
+            </button>
+          </div>
+          {emailError && (
+            <p id="email-error" className="text-xs text-red-500" role="alert">
+              {emailError}
+            </p>
+          )}
+          {submitError && (
+            <p className="text-xs text-red-500" role="alert">
+              {submitError}
+            </p>
+          )}
+        </form>
+
+        {/* Current shares */}
+        {shares.length > 0 && (
+          <div className="px-5 pb-4">
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">
+              Shared with
+            </p>
+            <ul className="space-y-2">
+              {shares.map((s) => (
+                <li key={s.id} className="flex items-center justify-between text-sm text-gray-700">
+                  <span className="truncate">{s.email}</span>
+                  <button
+                    onClick={() => handleRevoke(s.id)}
+                    disabled={revokingId === s.id}
+                    className="ml-3 text-gray-400 hover:text-red-500 disabled:opacity-50"
+                    aria-label={`Revoke access for ${s.email}`}
+                  >
+                    {revokingId === s.id ? (
+                      <Loader2 size={14} className="animate-spin" />
+                    ) : (
+                      <Trash2 size={14} />
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/cmmty/components/ShareModal/index.ts
+++ b/frontend/cmmty/components/ShareModal/index.ts
@@ -1,0 +1,2 @@
+export { default as ShareModal } from "./ShareModal";
+export type { ShareEntry } from "./ShareModal";


### PR DESCRIPTION
Implements four frontend components inside `frontend/cmmty/`.

- **FE-25** – `Navigation/Sidebar` (desktop) and `Navigation/Header` (mobile) with active-link highlighting, collapsible sidebar, admin-only link, and notification bell
- **FE-26** – `NotificationCenter` dropdown with unread badge, per-item mark-as-read, and mark-all-read
- **FE-27** – `ShareModal` with email validation, share submission, current-shares list, and revoke
- **FE-28** – `DocumentFilters` with debounced search (300 ms), status dropdown, date range, active-filter badge, and clear-all

Each component ships with unit tests.

Closes #391, closes #392, closes #393, closes #394