### PR TITLE
Add reusable frontend input modal toast and file upload components

### DIFF
--- a/frontend/cmmty/components/FileUpload/FileUpload.tsx
+++ b/frontend/cmmty/components/FileUpload/FileUpload.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { ChangeEvent, DragEvent, useRef, useState } from "react";
+import { UploadCloud } from "lucide-react";
+import { FileUploadProps } from "./types";
+import { validateFile } from "./validation";
+
+function formatFileSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function FileUpload({
+  allowedMimeTypes = [],
+  maxFileSizeBytes,
+  onFileSelect,
+  label = "Drag and drop a file here, or click to browse",
+}: FileUploadProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const processFile = (file: File | null) => {
+    if (!file) return;
+
+    const result = validateFile(file, allowedMimeTypes, maxFileSizeBytes);
+    if (!result.isValid) {
+      setSelectedFile(null);
+      setErrorMessage(result.errorMessage ?? "Invalid file");
+      return;
+    }
+
+    setErrorMessage(null);
+    setSelectedFile(file);
+    onFileSelect?.(file);
+  };
+
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+    processFile(event.dataTransfer.files.item(0));
+  };
+
+  const onDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(true);
+  };
+
+  const onDragLeave = () => setIsDragging(false);
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    processFile(event.target.files?.item(0) ?? null);
+  };
+
+  return (
+    <div className="w-full">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => inputRef.current?.click()}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+        className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-6 text-center transition ${
+          isDragging
+            ? "border-blue-500 bg-blue-50"
+            : "border-gray-300 bg-gray-50 hover:border-blue-400"
+        }`}
+      >
+        <UploadCloud className="mb-2 h-7 w-7 text-gray-600" />
+        <p className="text-sm font-medium text-gray-700">{label}</p>
+        {allowedMimeTypes.length > 0 ? (
+          <p className="mt-1 text-xs text-gray-500">
+            Allowed types: {allowedMimeTypes.join(", ")}
+          </p>
+        ) : null}
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        className="hidden"
+        onChange={onChange}
+        accept={allowedMimeTypes.length > 0 ? allowedMimeTypes.join(",") : undefined}
+      />
+
+      {selectedFile ? (
+        <div className="mt-3 rounded-md border border-gray-200 bg-white p-3 text-sm text-gray-700">
+          <p><span className="font-medium">Name:</span> {selectedFile.name}</p>
+          <p><span className="font-medium">Size:</span> {formatFileSize(selectedFile.size)}</p>
+          <p><span className="font-medium">Type:</span> {selectedFile.type || "Unknown"}</p>
+        </div>
+      ) : null}
+
+      {errorMessage ? <p className="mt-2 text-xs text-red-600">{errorMessage}</p> : null}
+    </div>
+  );
+}

--- a/frontend/cmmty/components/FileUpload/index.ts
+++ b/frontend/cmmty/components/FileUpload/index.ts
@@ -1,0 +1,3 @@
+export { default as FileUpload } from "./FileUpload";
+export { validateFile } from "./validation";
+export type { FileUploadProps, FileValidationResult } from "./types";

--- a/frontend/cmmty/components/FileUpload/types.ts
+++ b/frontend/cmmty/components/FileUpload/types.ts
@@ -1,0 +1,11 @@
+export interface FileUploadProps {
+  allowedMimeTypes?: string[];
+  maxFileSizeBytes?: number;
+  onFileSelect?: (file: File) => void;
+  label?: string;
+}
+
+export interface FileValidationResult {
+  isValid: boolean;
+  errorMessage?: string;
+}

--- a/frontend/cmmty/components/FileUpload/validation.test.ts
+++ b/frontend/cmmty/components/FileUpload/validation.test.ts
@@ -1,0 +1,26 @@
+import { validateFile } from "./validation";
+
+describe("validateFile", () => {
+  it("rejects unsupported MIME types", () => {
+    const file = new File(["content"], "notes.txt", { type: "text/plain" });
+    const result = validateFile(file, ["application/pdf"], 1024);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toMatch(/unsupported file type/i);
+  });
+
+  it("rejects files larger than max", () => {
+    const file = new File([new Uint8Array(2048)], "large.pdf", { type: "application/pdf" });
+    const result = validateFile(file, ["application/pdf"], 1024);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toMatch(/exceeds max size/i);
+  });
+
+  it("accepts valid files", () => {
+    const file = new File(["content"], "doc.pdf", { type: "application/pdf" });
+    const result = validateFile(file, ["application/pdf"], 1024 * 1024);
+
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/frontend/cmmty/components/FileUpload/validation.ts
+++ b/frontend/cmmty/components/FileUpload/validation.ts
@@ -1,0 +1,23 @@
+import { FileValidationResult } from "./types";
+
+export function validateFile(
+  file: File,
+  allowedMimeTypes: string[] = [],
+  maxFileSizeBytes?: number,
+): FileValidationResult {
+  if (allowedMimeTypes.length > 0 && !allowedMimeTypes.includes(file.type)) {
+    return {
+      isValid: false,
+      errorMessage: "Unsupported file type.",
+    };
+  }
+
+  if (maxFileSizeBytes && file.size > maxFileSizeBytes) {
+    return {
+      isValid: false,
+      errorMessage: `File exceeds max size of ${Math.round(maxFileSizeBytes / (1024 * 1024))}MB.`,
+    };
+  }
+
+  return { isValid: true };
+}

--- a/frontend/cmmty/components/Input/Input.test.tsx
+++ b/frontend/cmmty/components/Input/Input.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import Input from "./Input";
+
+describe("Input", () => {
+  it("shows error state and message", () => {
+    render(
+      <Input
+        id="email"
+        label="Email"
+        error
+        errorMessage="Email is required"
+        placeholder="Enter email"
+      />,
+    );
+
+    expect(screen.getByText("Email is required")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("toggles password visibility", () => {
+    render(<Input id="password" label="Password" type="password" />);
+
+    const input = screen.getByLabelText("Password");
+    expect(input).toHaveAttribute("type", "password");
+
+    fireEvent.click(screen.getByRole("button", { name: /show password/i }));
+    expect(input).toHaveAttribute("type", "text");
+  });
+});

--- a/frontend/cmmty/components/Input/Input.tsx
+++ b/frontend/cmmty/components/Input/Input.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useId, useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { InputProps } from "./types";
+
+export default function Input({
+  id,
+  type = "text",
+  label,
+  helperText,
+  error,
+  errorMessage,
+  leftIcon,
+  rightIcon,
+  className,
+  disabled,
+  ...props
+}: InputProps) {
+  const generatedId = useId();
+  const inputId = id || generatedId;
+  const helperId = `${inputId}-helper`;
+  const errorId = `${inputId}-error`;
+  const [showPassword, setShowPassword] = useState(false);
+
+  const resolvedType =
+    type === "password" && showPassword ? "text" : type;
+
+  return (
+    <div className="w-full">
+      {label ? (
+        <label htmlFor={inputId} className="mb-1 block text-sm font-medium text-gray-800">
+          {label}
+        </label>
+      ) : null}
+      <div className="relative">
+        {leftIcon ? (
+          <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-gray-500">
+            {leftIcon}
+          </span>
+        ) : null}
+        <input
+          id={inputId}
+          type={resolvedType}
+          disabled={disabled}
+          aria-invalid={Boolean(error)}
+          aria-describedby={error ? errorId : helperText ? helperId : undefined}
+          className={`w-full rounded-md border bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:ring-2 disabled:cursor-not-allowed disabled:bg-gray-100 ${leftIcon ? "pl-10" : ""} ${(rightIcon || type === "password") ? "pr-10" : ""} ${
+            error
+              ? "border-red-500 focus:border-red-500 focus:ring-red-200"
+              : "border-gray-300 focus:border-blue-500 focus:ring-blue-200"
+          } ${className ?? ""}`}
+          {...props}
+        />
+
+        {type === "password" ? (
+          <button
+            type="button"
+            onClick={() => setShowPassword((value) => !value)}
+            className="absolute inset-y-0 right-2 flex items-center px-1 text-gray-600 hover:text-gray-800"
+            aria-label={showPassword ? "Hide password" : "Show password"}
+          >
+            {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </button>
+        ) : rightIcon ? (
+          <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-gray-500">
+            {rightIcon}
+          </span>
+        ) : null}
+      </div>
+      {error && errorMessage ? (
+        <p id={errorId} className="mt-1 text-xs text-red-600">
+          {errorMessage}
+        </p>
+      ) : helperText ? (
+        <p id={helperId} className="mt-1 text-xs text-gray-500">
+          {helperText}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/cmmty/components/Input/index.ts
+++ b/frontend/cmmty/components/Input/index.ts
@@ -1,0 +1,2 @@
+export { default as Input } from "./Input";
+export type { InputProps, InputType } from "./types";

--- a/frontend/cmmty/components/Input/types.ts
+++ b/frontend/cmmty/components/Input/types.ts
@@ -1,0 +1,15 @@
+import { InputHTMLAttributes, ReactNode } from "react";
+
+export type InputType = "text" | "email" | "password";
+
+export interface InputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "type"> {
+  id?: string;
+  type?: InputType;
+  label?: string;
+  helperText?: string;
+  error?: boolean;
+  errorMessage?: string;
+  leftIcon?: ReactNode;
+  rightIcon?: ReactNode;
+}

--- a/frontend/cmmty/components/Modal/Modal.test.tsx
+++ b/frontend/cmmty/components/Modal/Modal.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import Modal from "./Modal";
+
+describe("Modal", () => {
+  it("renders provided content", () => {
+    render(
+      <Modal open title="Test Modal">
+        <p>Body content</p>
+      </Modal>,
+    );
+
+    expect(screen.getByText("Test Modal")).toBeInTheDocument();
+    expect(screen.getByText("Body content")).toBeInTheDocument();
+  });
+
+  it("calls onClose on ESC press", () => {
+    const onClose = jest.fn();
+
+    render(
+      <Modal open title="Esc test" onClose={onClose}>
+        <p>Body content</p>
+      </Modal>,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/cmmty/components/Modal/Modal.tsx
+++ b/frontend/cmmty/components/Modal/Modal.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect } from "react";
+import { X } from "lucide-react";
+import { ModalProps } from "./types";
+
+const sizeClasses = {
+  sm: "max-w-sm",
+  md: "max-w-lg",
+  lg: "max-w-2xl",
+};
+
+export default function Modal({
+  open,
+  title,
+  description,
+  children,
+  size = "md",
+  onClose,
+}: ModalProps) {
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose?.();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose, open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+      aria-describedby={description ? "modal-description" : undefined}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose?.();
+        }
+      }}
+    >
+      <div
+        className={`w-[92vw] rounded-lg bg-white p-6 shadow-xl transition-all duration-150 ease-out animate-in fade-in zoom-in-95 ${sizeClasses[size]}`}
+      >
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <h2 id="modal-title" className="text-lg font-semibold text-gray-900">
+              {title}
+            </h2>
+            {description ? (
+              <p id="modal-description" className="mt-1 text-sm text-gray-600">
+                {description}
+              </p>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            className="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            aria-label="Close modal"
+            onClick={() => onClose?.()}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/cmmty/components/Modal/index.ts
+++ b/frontend/cmmty/components/Modal/index.ts
@@ -1,0 +1,2 @@
+export { default as Modal } from "./Modal";
+export type { ModalProps, ModalSize } from "./types";

--- a/frontend/cmmty/components/Modal/types.ts
+++ b/frontend/cmmty/components/Modal/types.ts
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+
+export type ModalSize = "sm" | "md" | "lg";
+
+export interface ModalProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  children: ReactNode;
+  size?: ModalSize;
+  onClose?: () => void;
+}

--- a/frontend/cmmty/components/Toast/Toast.test.tsx
+++ b/frontend/cmmty/components/Toast/Toast.test.tsx
@@ -1,0 +1,54 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { ToastProvider, useToast } from "./useToast";
+import ToastStack from "./Toast";
+
+function Trigger() {
+  const { showToast } = useToast();
+  return (
+    <button onClick={() => showToast({ title: "Saved", type: "success", duration: 500 })}>
+      Trigger
+    </button>
+  );
+}
+
+describe("Toast", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("displays toast and dismisses automatically", () => {
+    render(
+      <ToastProvider>
+        <Trigger />
+        <ToastStack />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("Trigger"));
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.queryByText("Saved")).not.toBeInTheDocument();
+  });
+
+  it("dismisses manually", () => {
+    render(
+      <ToastProvider>
+        <Trigger />
+        <ToastStack />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("Trigger"));
+    fireEvent.click(screen.getByRole("button", { name: /dismiss notification/i }));
+    expect(screen.queryByText("Saved")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/cmmty/components/Toast/Toast.tsx
+++ b/frontend/cmmty/components/Toast/Toast.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { AlertCircle, CheckCircle2, Info, TriangleAlert, X } from "lucide-react";
+import { ComponentType } from "react";
+import { useToast } from "./useToast";
+import { ToastType } from "./types";
+
+const toastTheme: Record<ToastType, { icon: ComponentType<{ className?: string }>; style: string }> = {
+  success: {
+    icon: CheckCircle2,
+    style: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  },
+  error: {
+    icon: AlertCircle,
+    style: "border-red-200 bg-red-50 text-red-900",
+  },
+  warning: {
+    icon: TriangleAlert,
+    style: "border-amber-200 bg-amber-50 text-amber-900",
+  },
+  info: {
+    icon: Info,
+    style: "border-blue-200 bg-blue-50 text-blue-900",
+  },
+};
+
+export default function ToastStack() {
+  const { toasts, dismissToast } = useToast();
+
+  return (
+    <div className="pointer-events-none fixed right-4 top-4 z-[100] flex w-full max-w-sm flex-col gap-3">
+      {toasts.map((toast) => {
+        const theme = toastTheme[toast.type];
+        const Icon = theme.icon;
+
+        return (
+          <div
+            key={toast.id}
+            role="status"
+            className={`pointer-events-auto flex items-start gap-3 rounded-md border p-3 shadow-sm ${theme.style}`}
+          >
+            <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium">{toast.title}</p>
+              {toast.description ? (
+                <p className="mt-1 text-xs opacity-80">{toast.description}</p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              onClick={() => dismissToast(toast.id)}
+              className="rounded p-1 opacity-70 hover:bg-black/5 hover:opacity-100"
+              aria-label="Dismiss notification"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/cmmty/components/Toast/index.ts
+++ b/frontend/cmmty/components/Toast/index.ts
@@ -1,0 +1,3 @@
+export { default as ToastStack } from "./Toast";
+export { ToastProvider, useToast } from "./useToast";
+export type { ToastType, ToastItem, ToastOptions } from "./types";

--- a/frontend/cmmty/components/Toast/types.ts
+++ b/frontend/cmmty/components/Toast/types.ts
@@ -1,0 +1,14 @@
+export type ToastType = "success" | "error" | "warning" | "info";
+
+export interface ToastOptions {
+  title: string;
+  description?: string;
+  type?: ToastType;
+  duration?: number;
+}
+
+export interface ToastItem extends ToastOptions {
+  id: string;
+  type: ToastType;
+  duration: number;
+}

--- a/frontend/cmmty/components/Toast/useToast.tsx
+++ b/frontend/cmmty/components/Toast/useToast.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import { ToastItem, ToastOptions } from "./types";
+
+interface ToastContextValue {
+  toasts: ToastItem[];
+  showToast: (options: ToastOptions) => void;
+  dismissToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback((options: ToastOptions) => {
+    const id = crypto.randomUUID();
+    const toast: ToastItem = {
+      id,
+      title: options.title,
+      description: options.description,
+      type: options.type ?? "info",
+      duration: options.duration ?? 4000,
+    };
+
+    setToasts((current) => [...current, toast]);
+
+    window.setTimeout(() => {
+      setToasts((current) => current.filter((item) => item.id !== id));
+    }, toast.duration);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      toasts,
+      showToast,
+      dismissToast,
+    }),
+    [dismissToast, showToast, toasts],
+  );
+
+  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
### Motivation
- Provide reusable UI building blocks for forms and notifications in the frontend by implementing Input, Modal, Toast, and FileUpload components.
- Consolidate common patterns (validation, accessibility, toast provider) so feature pages can reuse them.

### Description
- Add `Input` component with label/helper/error states, optional icons, and password show/hide (`frontend/cmmty/components/Input`).
- Add `Modal` component with ESC and overlay-close behavior, sizes (`sm|md|lg`) and accessible attributes (`frontend/cmmty/components/Modal`).
- Add toast system (`ToastProvider`, `useToast`, `ToastStack`) with types, auto-dismiss and manual dismiss (`frontend/cmmty/components/Toast`).
- Add `FileUpload` drag-drop/click uploader with MIME and size validation and a reusable `validateFile` util (`frontend/cmmty/components/FileUpload`).
- Add unit tests for Input, Modal, Toast, and FileUpload validation, and small type fixes; committed and prepared as a single PR that closes the related issues.
- Closes #383
- Closes #384
- Closes #385
- Closes #386

### Testing
- Added unit tests under each component folder for `Input`, `Modal`, `Toast`, and `FileUpload` validation (files present in `frontend/cmmty/components/*/*.test.tsx`); tests were executed with `npm test` but the run failed due to Jest/Babel transform configuration not present in this repo (JSX/TSX parsing errors).
- Type check with `npx tsc --noEmit` failed due to missing test runner typings (recommend adding `@types/jest`).
- Attempted dependency provisioning (`npm install --package-lock-only`) failed to fetch `@radix-ui/react-dialog` due to registry 403, so some runtime deps were not installed.
