### PR TITLE
feat: PDF preview, skeleton loaders, error boundary, 404 page & risk …

### DIFF
--- a/frontend/cmmty/components/RiskFlagChart/RiskFlagChart.test.tsx
+++ b/frontend/cmmty/components/RiskFlagChart/RiskFlagChart.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import RiskFlagChart, { getBarWidth } from "./index";
+
+describe("getBarWidth", () => {
+  it("returns 0% when total is zero", () => {
+    expect(getBarWidth(10, 0)).toBe("0%");
+  });
+
+  it("returns 0% when weight is zero", () => {
+    expect(getBarWidth(0, 50)).toBe("0%");
+  });
+
+  it("calculates width relative to total score", () => {
+    expect(getBarWidth(25, 100)).toBe("25%");
+    expect(getBarWidth(33, 100)).toBe("33%");
+    expect(getBarWidth(67, 100)).toBe("67%");
+  });
+});
+
+describe("RiskFlagChart", () => {
+  it("renders a message when no flags are detected", () => {
+    render(<RiskFlagChart flags={[]} />);
+    expect(screen.getByText("No risk flags detected.")).toBeInTheDocument();
+  });
+
+  it("renders each detected flag with name, points, and bar", () => {
+    render(
+      <RiskFlagChart
+        flags={[
+          { id: "1", name: "High Severity", weight: 40 },
+          { id: "2", name: "Minor Issue", weight: 10 },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("High Severity")).toBeInTheDocument();
+    expect(screen.getByText("40 pts")).toBeInTheDocument();
+    expect(screen.getByText("Minor Issue")).toBeInTheDocument();
+    expect(screen.getByText("10 pts")).toBeInTheDocument();
+
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars).toHaveLength(2);
+    expect(bars[0]).toHaveAttribute("aria-label", "High Severity contributes 80% of total risk");
+    expect(bars[1]).toHaveAttribute("aria-label", "Minor Issue contributes 20% of total risk");
+  });
+});

--- a/frontend/cmmty/components/RiskFlagChart/index.tsx
+++ b/frontend/cmmty/components/RiskFlagChart/index.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React from "react";
+
+export interface RiskFlag {
+  id: string;
+  name: string;
+  weight: number;
+}
+
+export const getFlagLevel = (weight: number, total: number) => {
+  if (total <= 0) return "low";
+  const share = weight / total;
+  if (share > 0.66) return "high";
+  if (share > 0.33) return "medium";
+  return "low";
+};
+
+export const getBarWidth = (weight: number, total: number) => {
+  if (total <= 0 || weight <= 0) return "0%";
+  return `${Math.round((weight / total) * 100)}%`;
+};
+
+interface RiskFlagChartProps {
+  flags: RiskFlag[];
+}
+
+const levelStyles: Record<string, string> = {
+  low: "bg-gray-300 text-gray-900",
+  medium: "bg-amber-400 text-amber-950",
+  high: "bg-red-500 text-white",
+};
+
+export default function RiskFlagChart({ flags }: RiskFlagChartProps) {
+  const totalScore = flags.reduce((sum, flag) => sum + Math.max(flag.weight, 0), 0);
+
+  if (flags.length === 0 || totalScore === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-sm text-gray-600">
+        No risk flags detected.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {flags.map((flag) => {
+        const width = getBarWidth(flag.weight, totalScore);
+        const level = getFlagLevel(flag.weight, totalScore);
+        const barClasses = levelStyles[level] ?? levelStyles.low;
+
+        return (
+          <div key={flag.id} className="space-y-2">
+            <div className="flex items-center justify-between text-sm font-medium text-gray-800">
+              <span>{flag.name}</span>
+              <span>{flag.weight} pts</span>
+            </div>
+            <div className="h-10 overflow-hidden rounded-full bg-gray-200">
+              <div
+                role="progressbar"
+                aria-label={`${flag.name} contributes ${width} of total risk`}
+                aria-valuenow={flag.weight}
+                aria-valuemin={0}
+                aria-valuemax={totalScore}
+                className={`h-full rounded-full ${barClasses} transition-all duration-300 ease-out`}
+                style={{ width }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
Changes

### #395 — PDF Document Inline Preview [FE-29]
- \`frontend/cmmty/components/PdfPreview/\`
- react-pdf renderer with iframe fallback
- Prev/next navigation with current page / total pages display
- Loading skeleton while PDF loads
- Error state on load failure
- Tests: page navigation logic

### #396 — Skeleton Loading Screen Components [FE-30]
- \`frontend/cmmty/components/Skeleton/\`
- Variants: table row, document card, stat summary card, detail page
- Tailwind \`animate-pulse\` on all variants
- Layout matches real content shape
- Tests: each variant renders without errors

### #397 — Error Boundary & Custom 404 Page [FE-31]
- \`frontend/cmmty/components/ErrorBoundary/\` — class-based React error boundary
- User-friendly error UI with Reload Page button
- Console logging of caught errors
- \`frontend/cmmty/pages/not-found/\` — 404 page with icon, message, Back to Home
- Tests: error boundary catch behavior

### #398 — Risk Flag Breakdown Bar Chart [FE-32]
- \`frontend/cmmty/components/RiskFlagChart/\`
- Horizontal bar per detected flag, width proportional to weight
- Flag name + point value labelled on each bar
- Color coding: gray / amber / red by weight tier
- Empty state when no flags detected
- Tests: bar width calculation

## Checklist
- [x] All files inside \`frontend/cmmty/\` only
- [x] No files outside contribution folder modified
- [x] Unit tests written for all four components
- [x] PR targets main

## Closes
Closes #395
Closes #396
Closes #397
Closes #398