### PR TITLE
Merge pull request #443 from lynaDev2/feature/issues-395-396-397-398-…

### DIFF
--- a/contract/cmmty/revoke/batch-verify/handler.rs
+++ b/contract/cmmty/revoke/batch-verify/handler.rs
@@ -1,0 +1,301 @@
+use axum::{extract::State, http::StatusCode, Json};
+use futures::future::join_all;
+
+use crate::batch_verify::types::{BatchVerifyRequest, BatchVerifyResponse, HashResult};
+use crate::shared::{AppError, AppState, stellar};
+
+const MAX_BATCH_SIZE: usize = 50;
+
+/// POST /cmmty/verify/batch
+///
+/// Verifies up to 50 document hashes in a single request.
+///
+/// For each hash:
+///   1. Check the in-memory cache → cache hit: return cached result immediately.
+///   2. Cache miss: fetch from Stellar, cache the result, then return it.
+///
+/// The response preserves the original request ordering.
+pub async fn batch_verify_handler(
+    State(state): State<AppState>,
+    Json(payload): Json<BatchVerifyRequest>,
+) -> Result<Json<BatchVerifyResponse>, AppError> {
+    if payload.hashes.len() > MAX_BATCH_SIZE {
+        return Err(AppError::BadRequest(format!(
+            "too many hashes: maximum is {MAX_BATCH_SIZE}, got {}",
+            payload.hashes.len()
+        )));
+    }
+
+    // Process each hash concurrently, respecting cache
+    let futures = payload.hashes.iter().map(|hash| {
+        let state = state.clone();
+        let hash = hash.clone();
+        async move { resolve_hash(state, hash).await }
+    });
+
+    let results = join_all(futures).await;
+
+    Ok(Json(BatchVerifyResponse { results }))
+}
+
+/// Resolve a single hash, using the cache when possible.
+async fn resolve_hash(state: AppState, hash: String) -> HashResult {
+    // ── 1. Cache lookup ─────────────────────────────────────────────────────
+    if let Some(cached) = state.cache.get(&hash).await {
+        state.metrics.cache_hits_total.inc();
+
+        // Check if the hash has been revoked
+        let revoked = cached.revoked.unwrap_or(false);
+        return HashResult {
+            hash,
+            verified: cached.verified && !revoked,
+            revoked: Some(revoked),
+            tx_id: cached.tx_id,
+            anchored_at: cached.anchored_at,
+        };
+    }
+
+    state.metrics.cache_misses_total.inc();
+    state.metrics.verify_requests_total.inc();
+
+    // ── 2. Stellar lookup ────────────────────────────────────────────────────
+    let anchor_result = stellar::fetch_manage_data(
+        &state.stellar_client,
+        &state.account_keypair,
+        &hash,
+    )
+    .await;
+
+    match anchor_result {
+        Err(e) => {
+            state.metrics.stellar_errors_total.inc();
+            tracing::error!("Stellar error for hash {}: {}", hash, e);
+            HashResult {
+                hash,
+                verified: false,
+                revoked: None,
+                tx_id: None,
+                anchored_at: None,
+            }
+        }
+        Ok(None) => {
+            // Not anchored → cache negative result briefly
+            state
+                .cache
+                .insert(
+                    hash.clone(),
+                    crate::shared::cache::CachedVerify {
+                        verified: false,
+                        revoked: None,
+                        tx_id: None,
+                        anchored_at: None,
+                    },
+                )
+                .await;
+            HashResult {
+                hash,
+                verified: false,
+                revoked: Some(false),
+                tx_id: None,
+                anchored_at: None,
+            }
+        }
+        Ok(Some(record)) => {
+            // Check for a subsequent revocation entry
+            let revoke_key = format!("revoked_{}", hash);
+            let is_revoked = stellar::fetch_manage_data(
+                &state.stellar_client,
+                &state.account_keypair,
+                &revoke_key,
+            )
+            .await
+            .unwrap_or(None)
+            .is_some();
+
+            let result = HashResult {
+                hash: hash.clone(),
+                verified: !is_revoked,
+                revoked: Some(is_revoked),
+                tx_id: Some(record.tx_id.clone()),
+                anchored_at: Some(record.timestamp.clone()),
+            };
+
+            state
+                .cache
+                .insert(
+                    hash,
+                    crate::shared::cache::CachedVerify {
+                        verified: !is_revoked,
+                        revoked: Some(is_revoked),
+                        tx_id: Some(record.tx_id),
+                        anchored_at: Some(record.timestamp),
+                    },
+                )
+                .await;
+
+            result
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::test_helpers::mock_state;
+    use axum::{body::Body, http::Request};
+    use serde_json::{json, Value};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn batch_verify_returns_400_for_more_than_50_hashes() {
+        let state = mock_state().await;
+        let app = crate::router(state);
+
+        let hashes: Vec<String> = (0..=50).map(|i| format!("hash{:03}", i)).collect();
+        let body = json!({ "hashes": hashes }).to_string();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/cmmty/verify/batch")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn batch_verify_returns_result_per_hash() {
+        let state = mock_state().await;
+        let app = crate::router(state);
+
+        let body = json!({ "hashes": ["aaa", "bbb", "ccc"] }).to_string();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/cmmty/verify/batch")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap();
+        let results = json["results"].as_array().unwrap();
+        assert_eq!(results.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn batch_verify_cache_hit_does_not_call_stellar_twice() {
+        let state = mock_state().await;
+
+        // Pre-populate cache with a known hash
+        state
+            .cache
+            .insert(
+                "cached_hash_xyz".to_string(),
+                crate::shared::cache::CachedVerify {
+                    verified: true,
+                    revoked: Some(false),
+                    tx_id: Some("txCached".to_string()),
+                    anchored_at: Some("2024-06-01T00:00:00Z".to_string()),
+                },
+            )
+            .await;
+
+        let initial_hits = state.metrics.cache_hits_total.get() as u64;
+        let initial_misses = state.metrics.cache_misses_total.get() as u64;
+
+        let body = json!({ "hashes": ["cached_hash_xyz"] }).to_string();
+        let app = crate::router(state.clone());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/cmmty/verify/batch")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Cache hits counter should have incremented; misses should not
+        assert_eq!(
+            state.metrics.cache_hits_total.get() as u64,
+            initial_hits + 1
+        );
+        assert_eq!(
+            state.metrics.cache_misses_total.get() as u64,
+            initial_misses
+        );
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap();
+        let result = &json["results"][0];
+        assert_eq!(result["verified"], true);
+        assert_eq!(result["txId"], "txCached");
+    }
+
+    #[tokio::test]
+    async fn batch_verify_partial_cache_hit() {
+        let state = mock_state().await;
+
+        // Only "hash_a" is cached; "hash_b" must go to Stellar
+        state
+            .cache
+            .insert(
+                "hash_a".to_string(),
+                crate::shared::cache::CachedVerify {
+                    verified: true,
+                    revoked: Some(false),
+                    tx_id: Some("txA".to_string()),
+                    anchored_at: Some("2024-07-01T00:00:00Z".to_string()),
+                },
+            )
+            .await;
+
+        let body = json!({ "hashes": ["hash_a", "hash_b"] }).to_string();
+        let app = crate::router(state.clone());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/cmmty/verify/batch")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // One hit, one miss
+        assert_eq!(state.metrics.cache_hits_total.get() as u64, 1);
+        assert_eq!(state.metrics.cache_misses_total.get() as u64, 1);
+    }
+
+    #[tokio::test]
+    async fn batch_verify_exact_50_hashes_accepted() {
+        let state = mock_state().await;
+        let app = crate::router(state);
+
+        let hashes: Vec<String> = (0..50).map(|i| format!("hash{:03}", i)).collect();
+        let body = json!({ "hashes": hashes }).to_string();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/cmmty/verify/batch")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/contract/cmmty/revoke/batch-verify/mod.rs
+++ b/contract/cmmty/revoke/batch-verify/mod.rs
@@ -1,0 +1,4 @@
+pub mod handler;
+pub mod types;
+
+pub use handler::batch_verify_handler;

--- a/contract/cmmty/revoke/batch-verify/types.rs
+++ b/contract/cmmty/revoke/batch-verify/types.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+/// Request body for `POST /cmmty/verify/batch`.
+#[derive(Debug, Deserialize)]
+pub struct BatchVerifyRequest {
+    /// List of document hashes to verify. Maximum 50 entries.
+    pub hashes: Vec<String>,
+}
+
+/// The verification result for a single hash.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HashResult {
+    /// The document hash that was queried.
+    pub hash: String,
+
+    /// `true` if the hash is anchored on Stellar and has NOT been revoked.
+    pub verified: bool,
+
+    /// `true` if a revocation record exists for this hash.
+    /// `None` when a Stellar error prevented the revocation check.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revoked: Option<bool>,
+
+    /// The Stellar transaction ID of the anchor operation, if found.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_id: Option<String>,
+
+    /// ISO-8601 timestamp from the anchor ledger close time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchored_at: Option<String>,
+}
+
+/// Response body for `POST /cmmty/verify/batch`.
+#[derive(Debug, Serialize)]
+pub struct BatchVerifyResponse {
+    /// One result per hash, in the same order as the request.
+    pub results: Vec<HashResult>,
+}

--- a/contract/cmmty/revoke/handler.rs
+++ b/contract/cmmty/revoke/handler.rs
@@ -1,0 +1,156 @@
+use axum::{extract::State, http::StatusCode, Json};
+use chrono::Utc;
+use serde_json::json;
+
+use crate::revoke::types::{RevokeRequest, RevokeResponse};
+use crate::shared::{AppError, AppState, stellar};
+
+/// POST /cmmty/revoke
+///
+/// Marks a previously anchored document hash as revoked by writing a
+/// `manageData` operation to Stellar with the key `revoked_<hash>`.
+pub async fn revoke_handler(
+    State(state): State<AppState>,
+    Json(payload): Json<RevokeRequest>,
+) -> Result<Json<RevokeResponse>, AppError> {
+    let hash = payload.hash.trim().to_string();
+
+    if hash.is_empty() {
+        return Err(AppError::BadRequest("hash must not be empty".into()));
+    }
+
+    // Increment Prometheus counters (no-op if metrics feature is disabled)
+    state.metrics.anchor_requests_total.inc();
+
+    let manage_data_key = format!("revoked_{}", hash);
+
+    // Write revocation record to Stellar via manageData
+    let tx_hash = stellar::write_manage_data(
+        &state.stellar_client,
+        &state.account_keypair,
+        &manage_data_key,
+        // value: RFC-3339 timestamp at the moment of revocation
+        Some(Utc::now().to_rfc3339().as_bytes().to_vec()),
+    )
+    .await
+    .map_err(|e| {
+        state.metrics.stellar_errors_total.inc();
+        AppError::StellarError(e.to_string())
+    })?;
+
+    let revoked_at = Utc::now();
+
+    // Invalidate any cached verify result for this hash so subsequent
+    // verify calls re-fetch from Stellar and see the revocation.
+    state.cache.invalidate(&hash).await;
+
+    let response = RevokeResponse {
+        tx_hash,
+        revoked_at: revoked_at.to_rfc3339(),
+    };
+
+    Ok(Json(response))
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::test_helpers::{mock_state, make_request};
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt; // for `.oneshot()`
+
+    #[tokio::test]
+    async fn revoke_returns_tx_hash_and_timestamp() {
+        let state = mock_state().await;
+        let app = crate::router(state.clone());
+
+        let body = json!({ "hash": "abc123def456" }).to_string();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/cmmty/revoke")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert!(json.get("tx_hash").is_some());
+        assert!(json.get("revoked_at").is_some());
+    }
+
+    #[tokio::test]
+    async fn revoke_empty_hash_returns_400() {
+        let state = mock_state().await;
+        let app = crate::router(state);
+
+        let body = json!({ "hash": "" }).to_string();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/cmmty/revoke")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn verify_after_revoke_returns_revoked_true() {
+        let state = mock_state().await;
+
+        // First anchor the hash so it exists
+        let hash = "deadbeef1234";
+        stellar::write_manage_data(
+            &state.stellar_client,
+            &state.account_keypair,
+            hash,
+            Some(b"anchored".to_vec()),
+        )
+        .await
+        .unwrap();
+
+        // Now revoke it
+        stellar::write_manage_data(
+            &state.stellar_client,
+            &state.account_keypair,
+            &format!("revoked_{}", hash),
+            Some(chrono::Utc::now().to_rfc3339().as_bytes().to_vec()),
+        )
+        .await
+        .unwrap();
+
+        state.cache.invalidate(hash).await;
+
+        let app = crate::router(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/cmmty/verify")
+            .header("content-type", "application/json")
+            .body(Body::from(json!({ "hash": hash }).to_string()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(json["verified"], false);
+        assert_eq!(json["revoked"], true);
+    }
+}

--- a/contract/cmmty/revoke/history/handler.rs
+++ b/contract/cmmty/revoke/history/handler.rs
@@ -1,0 +1,175 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+
+use crate::history::types::{EventType, HistoryEvent, HistoryResponse};
+use crate::shared::{AppError, AppState, stellar};
+
+/// GET /cmmty/history/:hash
+///
+/// Returns all verification events (ANCHORED, REVOKED) for a given document
+/// hash, ordered chronologically (oldest first).
+///
+/// This is implemented by scanning Stellar account data for:
+///   - A key equal to `<hash>`          → ANCHORED event
+///   - A key equal to `revoked_<hash>`  → REVOKED  event
+///
+/// Each `manageData` entry stores the transaction hash and ledger close time
+/// that was written at anchor/revoke time, so we surface those directly.
+pub async fn history_handler(
+    State(state): State<AppState>,
+    Path(hash): Path<String>,
+) -> Result<Json<HistoryResponse>, AppError> {
+    let hash = hash.trim().to_string();
+
+    if hash.is_empty() {
+        return Err(AppError::BadRequest("hash path param must not be empty".into()));
+    }
+
+    // Fetch all manageData entries for the service account from Stellar
+    let account_data = stellar::fetch_account_data(&state.stellar_client, &state.account_keypair)
+        .await
+        .map_err(|e| {
+            state.metrics.stellar_errors_total.inc();
+            AppError::StellarError(e.to_string())
+        })?;
+
+    let mut events: Vec<HistoryEvent> = Vec::new();
+
+    // ANCHORED event ─ key == hash
+    if let Some(record) = account_data.get(&hash) {
+        events.push(HistoryEvent {
+            event_type: EventType::Anchored,
+            tx_id: record.tx_id.clone(),
+            ledger: record.ledger,
+            timestamp: record.timestamp.clone(),
+        });
+    }
+
+    // REVOKED event ─ key == "revoked_<hash>"
+    let revoke_key = format!("revoked_{}", hash);
+    if let Some(record) = account_data.get(&revoke_key) {
+        events.push(HistoryEvent {
+            event_type: EventType::Revoked,
+            tx_id: record.tx_id.clone(),
+            ledger: record.ledger,
+            timestamp: record.timestamp.clone(),
+        });
+    }
+
+    // Sort chronologically (oldest ledger first)
+    events.sort_by_key(|e| e.ledger);
+
+    Ok(Json(HistoryResponse { hash, events }))
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::test_helpers::mock_state;
+    use axum::{body::Body, http::Request};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn history_returns_empty_for_unknown_hash() {
+        let state = mock_state().await;
+        let app = crate::router(state);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/cmmty/history/unknownhash999")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(json["events"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn history_returns_anchored_event() {
+        let state = mock_state().await;
+        let hash = "anchoredhash01";
+
+        // Seed the mock Stellar store with an ANCHORED record
+        state
+            .stellar_client
+            .seed_manage_data(hash, "txAnchor001", 100, "2024-01-01T00:00:00Z")
+            .await;
+
+        let app = crate::router(state);
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/cmmty/history/{}", hash))
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap();
+        let events = json["events"].as_array().unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["eventType"], "ANCHORED");
+        assert_eq!(events[0]["txId"], "txAnchor001");
+    }
+
+    #[tokio::test]
+    async fn history_returns_anchored_then_revoked_in_order() {
+        let state = mock_state().await;
+        let hash = "fulllifecyclehash";
+
+        state
+            .stellar_client
+            .seed_manage_data(hash, "txAnchor002", 200, "2024-02-01T00:00:00Z")
+            .await;
+        state
+            .stellar_client
+            .seed_manage_data(
+                &format!("revoked_{}", hash),
+                "txRevoke002",
+                350,
+                "2024-03-01T00:00:00Z",
+            )
+            .await;
+
+        let app = crate::router(state);
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/cmmty/history/{}", hash))
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap();
+        let events = json["events"].as_array().unwrap();
+
+        assert_eq!(events.len(), 2);
+        // Oldest first
+        assert_eq!(events[0]["eventType"], "ANCHORED");
+        assert_eq!(events[0]["ledger"], 200);
+        assert_eq!(events[1]["eventType"], "REVOKED");
+        assert_eq!(events[1]["ledger"], 350);
+    }
+}

--- a/contract/cmmty/revoke/history/mod.rs
+++ b/contract/cmmty/revoke/history/mod.rs
@@ -1,0 +1,4 @@
+pub mod handler;
+pub mod types;
+
+pub use handler::history_handler;

--- a/contract/cmmty/revoke/history/types.rs
+++ b/contract/cmmty/revoke/history/types.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+/// The kind of event recorded for a document hash.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum EventType {
+    Anchored,
+    Revoked,
+}
+
+/// A single event in a document hash's lifecycle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryEvent {
+    /// Whether this was an anchor or revocation event.
+    pub event_type: EventType,
+
+    /// The Stellar transaction ID that recorded this event.
+    pub tx_id: String,
+
+    /// The Stellar ledger sequence number in which this event was finalized.
+    pub ledger: u32,
+
+    /// ISO-8601 / RFC-3339 close time of the ledger that contains the event.
+    pub timestamp: String,
+}
+
+/// Response body for `GET /cmmty/history/:hash`.
+#[derive(Debug, Serialize)]
+pub struct HistoryResponse {
+    /// The queried document hash.
+    pub hash: String,
+
+    /// All events, ordered chronologically (oldest first).
+    pub events: Vec<HistoryEvent>,
+}

--- a/contract/cmmty/revoke/metrics_endpoints/handler.rs
+++ b/contract/cmmty/revoke/metrics_endpoints/handler.rs
@@ -1,0 +1,146 @@
+use axum::{extract::State, http::StatusCode, response::Response};
+use axum::body::Body;
+use axum::http::header;
+use prometheus::{Encoder, TextEncoder};
+
+use crate::shared::{AppError, AppState};
+
+/// GET /cmmty/metrics
+///
+/// Returns all registered Prometheus metrics in the standard text exposition
+/// format (text/plain; version=0.0.4).
+pub async fn metrics_handler(
+    State(state): State<AppState>,
+) -> Result<Response<Body>, AppError> {
+    let encoder = TextEncoder::new();
+    let metric_families = state.metrics.registry.gather();
+
+    let mut buffer = Vec::new();
+    encoder
+        .encode(&metric_families, &mut buffer)
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            header::CONTENT_TYPE,
+            encoder.format_type(), // "text/plain; version=0.0.4"
+        )
+        .body(Body::from(buffer))
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(response)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::test_helpers::mock_state;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn metrics_endpoint_returns_200_with_prometheus_content_type() {
+        let state = mock_state().await;
+        let app = crate::router(state);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/cmmty/metrics")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.contains("text/plain"));
+    }
+
+    #[tokio::test]
+    async fn verify_counter_increments_are_reflected_in_metrics() {
+        let state = mock_state().await;
+
+        // Simulate two verify requests
+        state.metrics.verify_requests_total.inc();
+        state.metrics.verify_requests_total.inc();
+
+        let gathered = state.metrics.registry.gather();
+        let verify_family = gathered
+            .iter()
+            .find(|mf| mf.get_name() == "verify_requests_total")
+            .expect("verify_requests_total metric should be registered");
+
+        let value = verify_family.get_metric()[0].get_counter().get_value();
+        assert_eq!(value as u64, 2);
+    }
+
+    #[tokio::test]
+    async fn anchor_counter_increments_are_reflected_in_metrics() {
+        let state = mock_state().await;
+
+        state.metrics.anchor_requests_total.inc();
+
+        let gathered = state.metrics.registry.gather();
+        let family = gathered
+            .iter()
+            .find(|mf| mf.get_name() == "anchor_requests_total")
+            .expect("anchor_requests_total metric should be registered");
+
+        let value = family.get_metric()[0].get_counter().get_value();
+        assert_eq!(value as u64, 1);
+    }
+
+    #[tokio::test]
+    async fn cache_hit_miss_counters_are_registered() {
+        let state = mock_state().await;
+
+        state.metrics.cache_hits_total.inc();
+        state.metrics.cache_misses_total.inc();
+        state.metrics.cache_misses_total.inc();
+
+        let gathered = state.metrics.registry.gather();
+
+        let hits = gathered
+            .iter()
+            .find(|mf| mf.get_name() == "cache_hits_total")
+            .unwrap()
+            .get_metric()[0]
+            .get_counter()
+            .get_value();
+
+        let misses = gathered
+            .iter()
+            .find(|mf| mf.get_name() == "cache_misses_total")
+            .unwrap()
+            .get_metric()[0]
+            .get_counter()
+            .get_value();
+
+        assert_eq!(hits as u64, 1);
+        assert_eq!(misses as u64, 2);
+    }
+
+    #[tokio::test]
+    async fn stellar_errors_counter_is_registered() {
+        let state = mock_state().await;
+        state.metrics.stellar_errors_total.inc();
+
+        let gathered = state.metrics.registry.gather();
+        let family = gathered
+            .iter()
+            .find(|mf| mf.get_name() == "stellar_errors_total")
+            .expect("stellar_errors_total should be registered");
+
+        let value = family.get_metric()[0].get_counter().get_value();
+        assert_eq!(value as u64, 1);
+    }
+}

--- a/contract/cmmty/revoke/metrics_endpoints/mod.rs
+++ b/contract/cmmty/revoke/metrics_endpoints/mod.rs
@@ -1,0 +1,5 @@
+pub mod handler;
+pub mod registry;
+
+pub use handler::metrics_handler;
+pub use registry::MetricsRegistry;

--- a/contract/cmmty/revoke/metrics_endpoints/registry.rs
+++ b/contract/cmmty/revoke/metrics_endpoints/registry.rs
@@ -1,0 +1,113 @@
+use prometheus::{
+    exponential_buckets, Counter, Histogram, HistogramOpts, Opts, Registry,
+};
+use std::sync::Arc;
+
+/// Central metrics registry shared across all handlers via `AppState`.
+///
+/// Every new metric MUST be registered with `self.registry` in
+/// `MetricsRegistry::new()` so that `/cmmty/metrics` can gather them all.
+#[derive(Clone)]
+pub struct MetricsRegistry {
+    pub registry: Arc<Registry>,
+
+    /// Total number of verify requests received.
+    pub verify_requests_total: Counter,
+
+    /// Total number of anchor requests received.
+    pub anchor_requests_total: Counter,
+
+    /// Total number of cache hits (hash found in local cache).
+    pub cache_hits_total: Counter,
+
+    /// Total number of cache misses (hash not in local cache → Stellar lookup).
+    pub cache_misses_total: Counter,
+
+    /// Total number of errors returned by the Stellar RPC.
+    pub stellar_errors_total: Counter,
+
+    /// End-to-end request latency histogram (seconds).
+    pub request_duration_seconds: Histogram,
+}
+
+impl MetricsRegistry {
+    pub fn new() -> Self {
+        let registry = Arc::new(Registry::new());
+
+        // ── Counters ────────────────────────────────────────────────────────
+        let verify_requests_total = Counter::with_opts(
+            Opts::new("verify_requests_total", "Total verify requests received"),
+        )
+        .expect("metric creation failed");
+
+        let anchor_requests_total = Counter::with_opts(
+            Opts::new("anchor_requests_total", "Total anchor requests received"),
+        )
+        .expect("metric creation failed");
+
+        let cache_hits_total = Counter::with_opts(
+            Opts::new("cache_hits_total", "Total cache hits"),
+        )
+        .expect("metric creation failed");
+
+        let cache_misses_total = Counter::with_opts(
+            Opts::new("cache_misses_total", "Total cache misses"),
+        )
+        .expect("metric creation failed");
+
+        let stellar_errors_total = Counter::with_opts(
+            Opts::new("stellar_errors_total", "Total Stellar RPC errors"),
+        )
+        .expect("metric creation failed");
+
+        // ── Histogram ───────────────────────────────────────────────────────
+        // Buckets: 5 ms → ~10 s covering typical RPC latencies
+        let request_duration_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "request_duration_seconds",
+                "End-to-end HTTP request duration in seconds",
+            )
+            .buckets(
+                exponential_buckets(0.005, 2.0, 11)
+                    .expect("bucket config is valid"),
+            ),
+        )
+        .expect("metric creation failed");
+
+        // ── Register everything ─────────────────────────────────────────────
+        registry
+            .register(Box::new(verify_requests_total.clone()))
+            .expect("register verify_requests_total");
+        registry
+            .register(Box::new(anchor_requests_total.clone()))
+            .expect("register anchor_requests_total");
+        registry
+            .register(Box::new(cache_hits_total.clone()))
+            .expect("register cache_hits_total");
+        registry
+            .register(Box::new(cache_misses_total.clone()))
+            .expect("register cache_misses_total");
+        registry
+            .register(Box::new(stellar_errors_total.clone()))
+            .expect("register stellar_errors_total");
+        registry
+            .register(Box::new(request_duration_seconds.clone()))
+            .expect("register request_duration_seconds");
+
+        Self {
+            registry,
+            verify_requests_total,
+            anchor_requests_total,
+            cache_hits_total,
+            cache_misses_total,
+            stellar_errors_total,
+            request_duration_seconds,
+        }
+    }
+}
+
+impl Default for MetricsRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/contract/cmmty/revoke/mod.rs
+++ b/contract/cmmty/revoke/mod.rs
@@ -1,0 +1,4 @@
+pub mod handler;
+pub mod types;
+
+pub use handler::revoke_handler;

--- a/contract/cmmty/revoke/types.rs
+++ b/contract/cmmty/revoke/types.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+/// Request body for `POST /cmmty/revoke`.
+#[derive(Debug, Deserialize)]
+pub struct RevokeRequest {
+    /// The document hash (hex string) that should be marked as revoked.
+    pub hash: String,
+}
+
+/// Successful response for `POST /cmmty/revoke`.
+#[derive(Debug, Serialize)]
+pub struct RevokeResponse {
+    /// The Stellar transaction hash of the revocation record.
+    pub tx_hash: String,
+    /// ISO-8601 / RFC-3339 timestamp of when the revocation was written.
+    pub revoked_at: String,
+}

--- a/frontend/cmmty/components/RiskFlagChart/RiskFlagChart.test.tsx
+++ b/frontend/cmmty/components/RiskFlagChart/RiskFlagChart.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import RiskFlagChart, { getBarWidth } from "./index";
+
+describe("getBarWidth", () => {
+  it("returns 0% when total is zero", () => {
+    expect(getBarWidth(10, 0)).toBe("0%");
+  });
+
+  it("returns 0% when weight is zero", () => {
+    expect(getBarWidth(0, 50)).toBe("0%");
+  });
+
+  it("calculates width relative to total score", () => {
+    expect(getBarWidth(25, 100)).toBe("25%");
+    expect(getBarWidth(33, 100)).toBe("33%");
+    expect(getBarWidth(67, 100)).toBe("67%");
+  });
+});
+
+describe("RiskFlagChart", () => {
+  it("renders a message when no flags are detected", () => {
+    render(<RiskFlagChart flags={[]} />);
+    expect(screen.getByText("No risk flags detected.")).toBeInTheDocument();
+  });
+
+  it("renders each detected flag with name, points, and bar", () => {
+    render(
+      <RiskFlagChart
+        flags={[
+          { id: "1", name: "High Severity", weight: 40 },
+          { id: "2", name: "Minor Issue", weight: 10 },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("High Severity")).toBeInTheDocument();
+    expect(screen.getByText("40 pts")).toBeInTheDocument();
+    expect(screen.getByText("Minor Issue")).toBeInTheDocument();
+    expect(screen.getByText("10 pts")).toBeInTheDocument();
+
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars).toHaveLength(2);
+    expect(bars[0]).toHaveAttribute("aria-label", "High Severity contributes 80% of total risk");
+    expect(bars[1]).toHaveAttribute("aria-label", "Minor Issue contributes 20% of total risk");
+  });
+});

--- a/frontend/cmmty/components/RiskFlagChart/index.tsx
+++ b/frontend/cmmty/components/RiskFlagChart/index.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React from "react";
+
+export interface RiskFlag {
+  id: string;
+  name: string;
+  weight: number;
+}
+
+export const getFlagLevel = (weight: number, total: number) => {
+  if (total <= 0) return "low";
+  const share = weight / total;
+  if (share > 0.66) return "high";
+  if (share > 0.33) return "medium";
+  return "low";
+};
+
+export const getBarWidth = (weight: number, total: number) => {
+  if (total <= 0 || weight <= 0) return "0%";
+  return `${Math.round((weight / total) * 100)}%`;
+};
+
+interface RiskFlagChartProps {
+  flags: RiskFlag[];
+}
+
+const levelStyles: Record<string, string> = {
+  low: "bg-gray-300 text-gray-900",
+  medium: "bg-amber-400 text-amber-950",
+  high: "bg-red-500 text-white",
+};
+
+export default function RiskFlagChart({ flags }: RiskFlagChartProps) {
+  const totalScore = flags.reduce((sum, flag) => sum + Math.max(flag.weight, 0), 0);
+
+  if (flags.length === 0 || totalScore === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-sm text-gray-600">
+        No risk flags detected.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {flags.map((flag) => {
+        const width = getBarWidth(flag.weight, totalScore);
+        const level = getFlagLevel(flag.weight, totalScore);
+        const barClasses = levelStyles[level] ?? levelStyles.low;
+
+        return (
+          <div key={flag.id} className="space-y-2">
+            <div className="flex items-center justify-between text-sm font-medium text-gray-800">
+              <span>{flag.name}</span>
+              <span>{flag.weight} pts</span>
+            </div>
+            <div className="h-10 overflow-hidden rounded-full bg-gray-200">
+              <div
+                role="progressbar"
+                aria-label={`${flag.name} contributes ${width} of total risk`}
+                aria-valuenow={flag.weight}
+                aria-valuemin={0}
+                aria-valuemax={totalScore}
+                className={`h-full rounded-full ${barClasses} transition-all duration-300 ease-out`}
+                style={{ width }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
PR Description
feat(cmmty): add revoke, metrics, history, and batch-verify endpoints
Implements four new endpoints inside contract/cmmty/, each self-contained in its own sub-module:

POST /cmmty/revoke — writes a manageData(revoked_<hash>, timestamp) operation to Stellar and invalidates the local verify cache so subsequent calls immediately reflect the revocation.
GET /cmmty/metrics — exposes a Prometheus text-format scrape endpoint tracking verify_requests_total, anchor_requests_total, cache_hits_total, cache_misses_total, stellar_errors_total, and a request_duration_seconds histogram via a shared MetricsRegistry.
GET /cmmty/history/:hash — returns an ordered (ANCHORED → REVOKED) event list assembled from Stellar account data, sorted by ledger sequence.
POST /cmmty/verify/batch — accepts up to 50 hashes (returns 400 beyond that), checks the in-memory cache first for each, falls back to concurrent Stellar lookups, and includes revocation awareness in each result.

Closes #409
Closes #407
Closes #408
Closes #414