### PR TITLE
Feat/forgotpass

### DIFF
--- a/backend/cmmty/password-reset/dto/forgot-password.dto.ts
+++ b/backend/cmmty/password-reset/dto/forgot-password.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  email: string;
+}

--- a/backend/cmmty/password-reset/dto/reset-password.dto.ts
+++ b/backend/cmmty/password-reset/dto/reset-password.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @IsString()
+  token: string;
+
+  @IsString()
+  @MinLength(8)
+  newPassword: string;
+}

--- a/backend/cmmty/password-reset/password-reset-token.entity.ts
+++ b/backend/cmmty/password-reset/password-reset-token.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../src/users/entities/user.entity';
+
+@Entity('password_reset_tokens')
+export class PasswordResetToken {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index({ unique: true })
+  @Column()
+  token: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+
+  @Column({ name: 'expires_at', type: 'timestamp' })
+  expiresAt: Date;
+
+  @Column({ default: false })
+  used: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/cmmty/password-reset/password-reset.controller.ts
+++ b/backend/cmmty/password-reset/password-reset.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { PasswordResetService } from './password-reset.service';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
+
+@Controller('auth')
+export class PasswordResetController {
+  constructor(private readonly passwordResetService: PasswordResetService) {}
+
+  @Post('forgot-password')
+  forgotPassword(@Body() dto: ForgotPasswordDto) {
+    return this.passwordResetService.forgotPassword(dto);
+  }
+
+  @Post('reset-password')
+  resetPassword(@Body() dto: ResetPasswordDto) {
+    return this.passwordResetService.resetPassword(dto);
+  }
+}

--- a/backend/cmmty/password-reset/password-reset.module.ts
+++ b/backend/cmmty/password-reset/password-reset.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PasswordResetController } from './password-reset.controller';
+import { PasswordResetService } from './password-reset.service';
+import { PasswordResetToken } from './password-reset-token.entity';
+import { User } from '../../src/users/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User, PasswordResetToken])],
+  controllers: [PasswordResetController],
+  providers: [PasswordResetService],
+  exports: [PasswordResetService],
+})
+export class PasswordResetModule {}

--- a/backend/cmmty/password-reset/password-reset.service.spec.ts
+++ b/backend/cmmty/password-reset/password-reset.service.spec.ts
@@ -1,0 +1,165 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PasswordResetService } from './password-reset.service';
+import { User, UserRole } from '../../src/users/entities/user.entity';
+import { PasswordResetToken } from './password-reset-token.entity';
+import { BadRequestException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+
+describe('PasswordResetService', () => {
+  let service: PasswordResetService;
+  let mockUserRepository;
+  let mockPasswordResetRepository;
+
+  const mockUser: User = {
+    id: 'user-id-123',
+    email: 'test@example.com',
+    passwordHash: 'old_password_hash',
+    fullName: 'Jane Doe',
+    role: UserRole.USER,
+    isVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    mockUserRepository = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+    };
+
+    mockPasswordResetRepository = {
+      create: jest.fn((value) => value),
+      save: jest.fn(),
+      findOne: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PasswordResetService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepository,
+        },
+        {
+          provide: getRepositoryToken(PasswordResetToken),
+          useValue: mockPasswordResetRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<PasswordResetService>(PasswordResetService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('forgotPassword', () => {
+    it('should return 200 and create a password reset token when email exists', async () => {
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockPasswordResetRepository.save.mockResolvedValue({
+        id: 'token-id',
+        token: 'generated-token',
+        user: mockUser,
+        expiresAt: new Date(Date.now() + 3600000),
+        used: false,
+      });
+
+      const result = await service.forgotPassword({ email: 'test@example.com' });
+
+      expect(result.message).toContain('If the email is registered');
+      expect(mockPasswordResetRepository.create).toHaveBeenCalled();
+      expect(mockPasswordResetRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: expect.any(String),
+          user: mockUser,
+          used: false,
+        }),
+      );
+    });
+
+    it('should return 200 and not create a token when email does not exist', async () => {
+      mockUserRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.forgotPassword({ email: 'missing@example.com' });
+
+      expect(result.message).toContain('If the email is registered');
+      expect(mockPasswordResetRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('should reset the password when token is valid and unused', async () => {
+      const futureDate = new Date(Date.now() + 3600000);
+      const resetRecord: PasswordResetToken = {
+        id: 'reset-id-123',
+        token: 'valid-token',
+        user: mockUser,
+        expiresAt: futureDate,
+        used: false,
+        createdAt: new Date(),
+      };
+
+      mockPasswordResetRepository.findOne.mockResolvedValue(resetRecord);
+      mockUserRepository.update.mockResolvedValue({ affected: 1 });
+      mockPasswordResetRepository.save.mockResolvedValue({ ...resetRecord, used: true });
+
+      const result = await service.resetPassword({
+        token: 'valid-token',
+        newPassword: 'newPassword123',
+      });
+
+      expect(result.message).toBe('Password reset successfully');
+      expect(mockUserRepository.update).toHaveBeenCalledWith(mockUser.id, {
+        passwordHash: expect.any(String),
+      });
+      expect(mockPasswordResetRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ used: true }),
+      );
+    });
+
+    it('should reject when token is missing or invalid', async () => {
+      mockPasswordResetRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.resetPassword({ token: 'bad-token', newPassword: 'newPassword123' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject when token is expired', async () => {
+      const expiredRecord: PasswordResetToken = {
+        id: 'reset-id-123',
+        token: 'expired-token',
+        user: mockUser,
+        expiresAt: new Date(Date.now() - 1000),
+        used: false,
+        createdAt: new Date(Date.now() - 3600000),
+      };
+
+      mockPasswordResetRepository.findOne.mockResolvedValue(expiredRecord);
+
+      await expect(
+        service.resetPassword({ token: 'expired-token', newPassword: 'newPassword123' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject when token has already been used', async () => {
+      const usedRecord: PasswordResetToken = {
+        id: 'reset-id-123',
+        token: 'used-token',
+        user: mockUser,
+        expiresAt: new Date(Date.now() + 3600000),
+        used: true,
+        createdAt: new Date(Date.now() - 3600000),
+      };
+
+      mockPasswordResetRepository.findOne.mockResolvedValue(usedRecord);
+
+      await expect(
+        service.resetPassword({ token: 'used-token', newPassword: 'newPassword123' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/backend/cmmty/password-reset/password-reset.service.ts
+++ b/backend/cmmty/password-reset/password-reset.service.ts
@@ -1,0 +1,67 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { randomBytes } from 'crypto';
+import { User } from '../../src/users/entities/user.entity';
+import { PasswordResetToken } from './password-reset-token.entity';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
+
+@Injectable()
+export class PasswordResetService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(PasswordResetToken)
+    private readonly passwordResetRepository: Repository<PasswordResetToken>,
+  ) {}
+
+  async forgotPassword(dto: ForgotPasswordDto): Promise<{ message: string }> {
+    const email = dto.email?.trim().toLowerCase();
+    const user = await this.userRepository.findOne({ where: { email } });
+
+    if (user) {
+      const token = randomBytes(32).toString('hex');
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+
+      await this.passwordResetRepository.save(
+        this.passwordResetRepository.create({
+          token,
+          user,
+          expiresAt,
+          used: false,
+        }),
+      );
+    }
+
+    return {
+      message:
+        'If the email is registered, password reset instructions have been sent.',
+    };
+  }
+
+  async resetPassword(dto: ResetPasswordDto): Promise<{ message: string }> {
+    const token = dto.token?.trim();
+    const resetRecord = await this.passwordResetRepository.findOne({
+      where: { token },
+      relations: ['user'],
+    });
+
+    if (
+      !resetRecord ||
+      resetRecord.used ||
+      resetRecord.expiresAt.getTime() < Date.now()
+    ) {
+      throw new BadRequestException('Invalid or expired password reset token');
+    }
+
+    const passwordHash = await bcrypt.hash(dto.newPassword, 12);
+    await this.userRepository.update(resetRecord.user.id, { passwordHash });
+
+    resetRecord.used = true;
+    await this.passwordResetRepository.save(resetRecord);
+
+    return { message: 'Password reset successfully' };
+  }
+}


### PR DESCRIPTION
## Completed

Implemented the full password reset flow inside password-reset:

- `password-reset.module.ts`
- `password-reset.controller.ts`
- `password-reset.service.ts`
- `password-reset-token.entity.ts`
- `dto/forgot-password.dto.ts`
- `dto/reset-password.dto.ts`
- `password-reset.service.spec.ts`

Closes #338 

## Feature details

- Added `POST /cmmty/auth/forgot-password`
  - always returns `200`
  - creates a one-hour token only when the email exists
- Added `POST /cmmty/auth/reset-password`
  - accepts `token` and `newPassword`
  - expires tokens after 1 hour
  - marks tokens as used on successful reset

## Verification

- Ran `npx jest --rootDir . cmmty/password-reset/password-reset.service.spec.ts --runInBand`
- Result: `7 passed`

All changes are contained within cmmty only.

Made changes.

Closes #337 