### PR TITLE
feat(document-archive): implement document archiving feature

### DIFF
--- a/backend/cmmty/document-archive/README.md
+++ b/backend/cmmty/document-archive/README.md
@@ -1,0 +1,162 @@
+# Document Archive Module
+
+This module provides functionality to archive and unarchive documents within the SMALDA system.
+
+## Overview
+
+The Document Archive module allows users to move documents to an archived state, effectively hiding them from the default list without permanently deleting them. Archived documents can be unarchived at any time to restore them to the active state.
+
+## Features
+
+- **Archive documents**: Move documents to archived state via `POST /cmmty/documents/:id/archive`
+- **Unarchive documents**: Restore archived documents via `POST /cmmty/documents/:id/unarchive`
+- **List archived documents**: Retrieve paginated list of archived documents via `GET /cmmty/documents/archived`
+- **Filter non-archived documents**: Helper method to list only active documents
+- **Idempotent operations**: Archive/unarchive operations are safe to call multiple times
+
+## Architecture
+
+### Files
+
+- `document-archive.module.ts` - NestJS module definition
+- `document-archive.controller.ts` - HTTP request handlers
+- `document-archive.service.ts` - Business logic
+- `document-archive.service.spec.ts` - Unit tests
+- `dto/archive-response.dto.ts` - Response DTO for archive/unarchive operations
+- `dto/archived-documents-query.dto.ts` - Query parameters DTO for listing archived documents
+
+### Database Changes
+
+An `archived` column (boolean, default: false) has been added to the `documents` table to track the archive state of each document.
+
+## API Endpoints
+
+### Archive a Document
+
+```http
+POST /cmmty/documents/:id/archive
+Authorization: Bearer <JWT_TOKEN>
+```
+
+**Response (202 Accepted):**
+```json
+{
+  "id": "doc-123",
+  "title": "Document Title",
+  "archived": true,
+  "message": "Document archived successfully"
+}
+```
+
+**Error (404 Not Found):**
+```json
+{
+  "message": "Document with id doc-123 not found"
+}
+```
+
+### Unarchive a Document
+
+```http
+POST /cmmty/documents/:id/unarchive
+Authorization: Bearer <JWT_TOKEN>
+```
+
+**Response (202 Accepted):**
+```json
+{
+  "id": "doc-123",
+  "title": "Document Title",
+  "archived": false,
+  "message": "Document unarchived successfully"
+}
+```
+
+### List Archived Documents
+
+```http
+GET /cmmty/documents/archived?page=1&limit=10
+Authorization: Bearer <JWT_TOKEN>
+```
+
+**Response (200 OK):**
+```json
+{
+  "data": [
+    {
+      "id": "doc-1",
+      "ownerId": "user-123",
+      "title": "Archived Document 1",
+      "filePath": "/path/to/file1.pdf",
+      "fileHash": "abc123",
+      "fileSize": 2048,
+      "mimeType": "application/pdf",
+      "status": "verified",
+      "riskScore": 0.5,
+      "riskFlags": [],
+      "archived": true,
+      "createdAt": "2024-04-20T10:30:00Z",
+      "updatedAt": "2024-04-22T14:15:00Z"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "limit": 10
+}
+```
+
+## Service Methods
+
+### `archive(id: string): Promise<ArchiveResponseDto>`
+
+Archives a document by ID. Returns immediately if document is already archived.
+
+### `unarchive(id: string): Promise<ArchiveResponseDto>`
+
+Unarchives a document by ID. Returns immediately if document is not archived.
+
+### `getArchivedDocuments(page: number, limit: number): Promise<PaginatedArchivedDocuments>`
+
+Retrieves a paginated list of archived documents, ordered by creation date (newest first).
+
+### `getNonArchivedDocuments(page: number, limit: number): Promise<PaginatedArchivedDocuments>`
+
+Retrieves a paginated list of non-archived (active) documents, ordered by creation date (newest first).
+
+## Testing
+
+Comprehensive unit tests are included covering:
+
+- Successful archive/unarchive operations
+- Idempotent behavior (archive/unarchive already in that state)
+- Error handling (document not found)
+- Pagination for archived documents
+- State transitions (archive → unarchive → archive)
+- Filtering of archived vs non-archived documents
+
+Run tests with:
+```bash
+npm test -- document-archive.service.spec.ts
+```
+
+## Design Decisions
+
+1. **Soft Delete Pattern**: Uses a boolean flag instead of hard deletion to preserve data integrity and allow recovery.
+
+2. **Idempotent Operations**: Archive/unarchive endpoints are safe to call multiple times without side effects.
+
+3. **Paginated Responses**: List endpoints include pagination to handle large numbers of documents efficiently.
+
+4. **Separate Endpoint for Archived Documents**: Keeps the default list of documents clean by providing a separate endpoint for archived items.
+
+5. **JWT Authentication**: All endpoints require JWT authentication to ensure only authorized users can archive/unarchive documents.
+
+## Integration with Existing Services
+
+The module extends the Document entity with an `archived` boolean field. When querying for documents in other parts of the system (e.g., search, list), services should filter out archived documents by default unless explicitly requesting them.
+
+Example:
+```typescript
+// Get non-archived documents for a user
+const documents = await this.documentArchiveService.getNonArchivedDocuments(1, 10);
+```

--- a/backend/cmmty/document-archive/document-archive.controller.ts
+++ b/backend/cmmty/document-archive/document-archive.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Post, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { DocumentArchiveService } from './document-archive.service';
+import { ArchiveResponseDto } from './dto/archive-response.dto';
+import { ArchivedDocumentsQueryDto } from './dto/archived-documents-query.dto';
+import { JwtAuthGuard } from '../../src/auth/guards/jwt-auth.guard';
+
+@Controller('documents')
+@UseGuards(JwtAuthGuard)
+export class DocumentArchiveController {
+  constructor(private readonly documentArchiveService: DocumentArchiveService) {}
+
+  @Post(':id/archive')
+  async archive(@Param('id') id: string): Promise<ArchiveResponseDto> {
+    return this.documentArchiveService.archive(id);
+  }
+
+  @Post(':id/unarchive')
+  async unarchive(@Param('id') id: string): Promise<ArchiveResponseDto> {
+    return this.documentArchiveService.unarchive(id);
+  }
+
+  @Get('archived')
+  async getArchivedDocuments(@Query() query: ArchivedDocumentsQueryDto) {
+    const page = query.page || 1;
+    const limit = query.limit || 10;
+    return this.documentArchiveService.getArchivedDocuments(page, limit);
+  }
+}

--- a/backend/cmmty/document-archive/document-archive.module.ts
+++ b/backend/cmmty/document-archive/document-archive.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DocumentArchiveService } from './document-archive.service';
+import { DocumentArchiveController } from './document-archive.controller';
+import { Document } from '../../src/documents/entities/document.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Document])],
+  controllers: [DocumentArchiveController],
+  providers: [DocumentArchiveService],
+  exports: [DocumentArchiveService],
+})
+export class DocumentArchiveModule {}

--- a/backend/cmmty/document-archive/document-archive.service.spec.ts
+++ b/backend/cmmty/document-archive/document-archive.service.spec.ts
@@ -1,0 +1,371 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { DocumentArchiveService } from './document-archive.service';
+import { Document, DocumentStatus } from '../../src/documents/entities/document.entity';
+
+describe('DocumentArchiveService', () => {
+  let service: DocumentArchiveService;
+  let repository: Repository<Document>;
+
+  const mockDocument: Document = {
+    id: 'doc-123',
+    ownerId: 'user-123',
+    owner: null,
+    title: 'Test Document',
+    filePath: '/path/to/file.pdf',
+    fileHash: 'abc123',
+    fileSize: 1024,
+    mimeType: 'application/pdf',
+    status: DocumentStatus.VERIFIED,
+    riskScore: 0,
+    riskFlags: [],
+    archived: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockRepository = {
+    findOne: jest.fn(),
+    update: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DocumentArchiveService,
+        {
+          provide: getRepositoryToken(Document),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DocumentArchiveService>(DocumentArchiveService);
+    repository = module.get<Repository<Document>>(getRepositoryToken(Document));
+
+    // Reset mocks before each test
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('archive', () => {
+    it('should successfully archive a document', async () => {
+      const unArchivedDocument = { ...mockDocument, archived: false };
+      const archivedDocument = { ...mockDocument, archived: true };
+
+      mockRepository.findOne
+        .mockResolvedValueOnce(unArchivedDocument)
+        .mockResolvedValueOnce(archivedDocument);
+      mockRepository.update.mockResolvedValue({ affected: 1 });
+
+      const result = await service.archive('doc-123');
+
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'doc-123' },
+      });
+      expect(mockRepository.update).toHaveBeenCalledWith('doc-123', {
+        archived: true,
+      });
+      expect(result).toEqual({
+        id: 'doc-123',
+        title: 'Test Document',
+        archived: true,
+        message: 'Document archived successfully',
+      });
+    });
+
+    it('should return message when document is already archived', async () => {
+      const archivedDocument = { ...mockDocument, archived: true };
+
+      mockRepository.findOne.mockResolvedValue(archivedDocument);
+
+      const result = await service.archive('doc-123');
+
+      expect(result).toEqual({
+        id: 'doc-123',
+        title: 'Test Document',
+        archived: true,
+        message: 'Document is already archived',
+      });
+      expect(mockRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when document does not exist', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.archive('non-existent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('unarchive', () => {
+    it('should successfully unarchive a document', async () => {
+      const archivedDocument = { ...mockDocument, archived: true };
+      const unarchivedDocument = { ...mockDocument, archived: false };
+
+      mockRepository.findOne
+        .mockResolvedValueOnce(archivedDocument)
+        .mockResolvedValueOnce(unarchivedDocument);
+      mockRepository.update.mockResolvedValue({ affected: 1 });
+
+      const result = await service.unarchive('doc-123');
+
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'doc-123' },
+      });
+      expect(mockRepository.update).toHaveBeenCalledWith('doc-123', {
+        archived: false,
+      });
+      expect(result).toEqual({
+        id: 'doc-123',
+        title: 'Test Document',
+        archived: false,
+        message: 'Document unarchived successfully',
+      });
+    });
+
+    it('should return message when document is not archived', async () => {
+      const unarchivedDocument = { ...mockDocument, archived: false };
+
+      mockRepository.findOne.mockResolvedValue(unarchivedDocument);
+
+      const result = await service.unarchive('doc-123');
+
+      expect(result).toEqual({
+        id: 'doc-123',
+        title: 'Test Document',
+        archived: false,
+        message: 'Document is not archived',
+      });
+      expect(mockRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when document does not exist', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.unarchive('non-existent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('getArchivedDocuments', () => {
+    it('should return paginated archived documents', async () => {
+      const archivedDoc1 = { ...mockDocument, id: 'doc-1', archived: true };
+      const archivedDoc2 = { ...mockDocument, id: 'doc-2', archived: true };
+
+      const mockQueryBuilder = {
+        where: jest.fn().returnThis(),
+        getCount: jest.fn().mockResolvedValue(2),
+        skip: jest.fn().returnThis(),
+        take: jest.fn().returnThis(),
+        orderBy: jest.fn().returnThis(),
+        getMany: jest.fn().mockResolvedValue([archivedDoc1, archivedDoc2]),
+      };
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+      const result = await service.getArchivedDocuments(1, 10);
+
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalledWith('document');
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        'document.archived = :archived',
+        { archived: true },
+      );
+      expect(mockQueryBuilder.getCount).toHaveBeenCalled();
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(0);
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(10);
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'document.createdAt',
+        'DESC',
+      );
+      expect(result).toEqual({
+        data: [archivedDoc1, archivedDoc2],
+        total: 2,
+        page: 1,
+        limit: 10,
+      });
+    });
+
+    it('should handle pagination correctly for page 2', async () => {
+      const archivedDoc = { ...mockDocument, archived: true };
+
+      const mockQueryBuilder = {
+        where: jest.fn().returnThis(),
+        getCount: jest.fn().mockResolvedValue(25),
+        skip: jest.fn().returnThis(),
+        take: jest.fn().returnThis(),
+        orderBy: jest.fn().returnThis(),
+        getMany: jest.fn().mockResolvedValue([archivedDoc]),
+      };
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+      const result = await service.getArchivedDocuments(2, 10);
+
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(10);
+      expect(result.page).toBe(2);
+    });
+
+    it('should return empty list when no archived documents exist', async () => {
+      const mockQueryBuilder = {
+        where: jest.fn().returnThis(),
+        getCount: jest.fn().mockResolvedValue(0),
+        skip: jest.fn().returnThis(),
+        take: jest.fn().returnThis(),
+        orderBy: jest.fn().returnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+      const result = await service.getArchivedDocuments(1, 10);
+
+      expect(result).toEqual({
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+      });
+    });
+  });
+
+  describe('getNonArchivedDocuments', () => {
+    it('should return paginated non-archived documents', async () => {
+      const nonArchivedDoc1 = { ...mockDocument, id: 'doc-1', archived: false };
+      const nonArchivedDoc2 = { ...mockDocument, id: 'doc-2', archived: false };
+
+      const mockQueryBuilder = {
+        where: jest.fn().returnThis(),
+        getCount: jest.fn().mockResolvedValue(2),
+        skip: jest.fn().returnThis(),
+        take: jest.fn().returnThis(),
+        orderBy: jest.fn().returnThis(),
+        getMany: jest.fn().mockResolvedValue([nonArchivedDoc1, nonArchivedDoc2]),
+      };
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+      const result = await service.getNonArchivedDocuments(1, 10);
+
+      expect(mockRepository.createQueryBuilder).toHaveBeenCalledWith('document');
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        'document.archived = :archived',
+        { archived: false },
+      );
+      expect(mockQueryBuilder.getCount).toHaveBeenCalled();
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(0);
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(10);
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+        'document.createdAt',
+        'DESC',
+      );
+      expect(result).toEqual({
+        data: [nonArchivedDoc1, nonArchivedDoc2],
+        total: 2,
+        page: 1,
+        limit: 10,
+      });
+    });
+
+    it('should return only non-archived documents', async () => {
+      const nonArchivedDoc = { ...mockDocument, archived: false };
+
+      const mockQueryBuilder = {
+        where: jest.fn().returnThis(),
+        getCount: jest.fn().mockResolvedValue(1),
+        skip: jest.fn().returnThis(),
+        take: jest.fn().returnThis(),
+        orderBy: jest.fn().returnThis(),
+        getMany: jest.fn().mockResolvedValue([nonArchivedDoc]),
+      };
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+      const result = await service.getNonArchivedDocuments(1, 10);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].archived).toBe(false);
+    });
+
+    it('should return empty list when all documents are archived', async () => {
+      const mockQueryBuilder = {
+        where: jest.fn().returnThis(),
+        getCount: jest.fn().mockResolvedValue(0),
+        skip: jest.fn().returnThis(),
+        take: jest.fn().returnThis(),
+        orderBy: jest.fn().returnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+      const result = await service.getNonArchivedDocuments(1, 10);
+
+      expect(result).toEqual({
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+      });
+    });
+  });;
+
+  describe('state transitions', () => {
+    it('should transition from unarchived to archived to unarchived', async () => {
+      const unArchivedDocument = { ...mockDocument, archived: false };
+      const archivedDocument = { ...mockDocument, archived: true };
+
+      // First archive
+      mockRepository.findOne
+        .mockResolvedValueOnce(unArchivedDocument)
+        .mockResolvedValueOnce(archivedDocument)
+        // Then unarchive
+        .mockResolvedValueOnce(archivedDocument)
+        .mockResolvedValueOnce(unArchivedDocument);
+      mockRepository.update.mockResolvedValue({ affected: 1 });
+
+      const archiveResult = await service.archive('doc-123');
+      expect(archiveResult.archived).toBe(true);
+
+      const unarchiveResult = await service.unarchive('doc-123');
+      expect(unarchiveResult.archived).toBe(false);
+
+      expect(mockRepository.update).toHaveBeenCalledTimes(2);
+      expect(mockRepository.update).toHaveBeenNthCalledWith(1, 'doc-123', {
+        archived: true,
+      });
+      expect(mockRepository.update).toHaveBeenNthCalledWith(2, 'doc-123', {
+        archived: false,
+      });
+    });
+
+    it('should handle multiple consecutive archive calls idempotently', async () => {
+      const unArchivedDocument = { ...mockDocument, archived: false };
+      const archivedDocument = { ...mockDocument, archived: true };
+
+      mockRepository.findOne
+        .mockResolvedValueOnce(unArchivedDocument)
+        .mockResolvedValueOnce(archivedDocument)
+        .mockResolvedValueOnce(archivedDocument);
+      mockRepository.update.mockResolvedValue({ affected: 1 });
+
+      // First archive
+      const result1 = await service.archive('doc-123');
+      expect(result1.archived).toBe(true);
+
+      // Second archive (should be idempotent)
+      const result2 = await service.archive('doc-123');
+      expect(result2.archived).toBe(true);
+
+      expect(mockRepository.update).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/backend/cmmty/document-archive/document-archive.service.ts
+++ b/backend/cmmty/document-archive/document-archive.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Document } from '../../src/documents/entities/document.entity';
+import { ArchiveResponseDto } from './dto/archive-response.dto';
+
+export interface PaginatedArchivedDocuments {
+  data: Document[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+@Injectable()
+export class DocumentArchiveService {
+  constructor(
+    @InjectRepository(Document)
+    private readonly documentRepository: Repository<Document>,
+  ) {}
+
+  async archive(id: string): Promise<ArchiveResponseDto> {
+    const document = await this.documentRepository.findOne({ where: { id } });
+
+    if (!document) {
+      throw new NotFoundException(`Document with id ${id} not found`);
+    }
+
+    if (document.archived) {
+      return {
+        id: document.id,
+        title: document.title,
+        archived: true,
+        message: 'Document is already archived',
+      };
+    }
+
+    await this.documentRepository.update(id, { archived: true });
+    const updatedDocument = await this.documentRepository.findOne({ where: { id } });
+
+    return {
+      id: updatedDocument.id,
+      title: updatedDocument.title,
+      archived: updatedDocument.archived,
+      message: 'Document archived successfully',
+    };
+  }
+
+  async unarchive(id: string): Promise<ArchiveResponseDto> {
+    const document = await this.documentRepository.findOne({ where: { id } });
+
+    if (!document) {
+      throw new NotFoundException(`Document with id ${id} not found`);
+    }
+
+    if (!document.archived) {
+      return {
+        id: document.id,
+        title: document.title,
+        archived: false,
+        message: 'Document is not archived',
+      };
+    }
+
+    await this.documentRepository.update(id, { archived: false });
+    const updatedDocument = await this.documentRepository.findOne({ where: { id } });
+
+    return {
+      id: updatedDocument.id,
+      title: updatedDocument.title,
+      archived: updatedDocument.archived,
+      message: 'Document unarchived successfully',
+    };
+  }
+
+  async getArchivedDocuments(
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<PaginatedArchivedDocuments> {
+    const queryBuilder = this.documentRepository
+      .createQueryBuilder('document')
+      .where('document.archived = :archived', { archived: true });
+
+    const total = await queryBuilder.getCount();
+
+    const skip = (page - 1) * limit;
+    queryBuilder.skip(skip).take(limit).orderBy('document.createdAt', 'DESC');
+
+    const data = await queryBuilder.getMany();
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+    };
+  }
+
+  async getNonArchivedDocuments(
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<PaginatedArchivedDocuments> {
+    const queryBuilder = this.documentRepository
+      .createQueryBuilder('document')
+      .where('document.archived = :archived', { archived: false });
+
+    const total = await queryBuilder.getCount();
+
+    const skip = (page - 1) * limit;
+    queryBuilder.skip(skip).take(limit).orderBy('document.createdAt', 'DESC');
+
+    const data = await queryBuilder.getMany();
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+    };
+  }
+}

--- a/backend/cmmty/document-archive/dto/archive-response.dto.ts
+++ b/backend/cmmty/document-archive/dto/archive-response.dto.ts
@@ -1,0 +1,6 @@
+export class ArchiveResponseDto {
+  id: string;
+  title: string;
+  archived: boolean;
+  message: string;
+}

--- a/backend/cmmty/document-archive/dto/archived-documents-query.dto.ts
+++ b/backend/cmmty/document-archive/dto/archived-documents-query.dto.ts
@@ -1,0 +1,4 @@
+export class ArchivedDocumentsQueryDto {
+  page?: number = 1;
+  limit?: number = 10;
+}

--- a/backend/src/documents/entities/document.entity.ts
+++ b/backend/src/documents/entities/document.entity.ts
@@ -57,6 +57,9 @@ export class Document {
   @Column({ name: 'risk_flags', type: 'json', nullable: true })
   riskFlags?: string[];
 
+  @Column({ name: 'archived', type: 'boolean', default: false })
+  archived: boolean;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 


### PR DESCRIPTION
Closes #347;
Closes #348

- Add 'archived' boolean column to Document entity for soft deletion
- Create document-archive module in backend/cmmty/ with:
  - DocumentArchiveService with archive/unarchive/list methods
  - DocumentArchiveController with POST/GET endpoints
  - Comprehensive unit tests for state transitions
  - DTOs for request/response handling
- Implement POST /cmmty/documents/:id/archive endpoint
- Implement POST /cmmty/documents/:id/unarchive endpoint
- Implement GET /cmmty/documents/archived for listing archived documents
- Add getNonArchivedDocuments method to filter active documents
- Archive operations are idempotent (safe to call multiple times)
- All endpoints require JWT authentication
- Add comprehensive README documentation

Closes #349;

Closes #350