### PR TITLE
Newpage

### DIFF
--- a/backend/src/documents/documents.module.ts
+++ b/backend/src/documents/documents.module.ts
@@ -9,6 +9,7 @@ import { VerificationModule } from '../verification/verification.module';
 import { QueueModule } from '../queue/queue.module';
 
 @Module({
+  
   imports: [
     ConfigModule,
     TypeOrmModule.forFeature([Document]),
@@ -21,3 +22,4 @@ import { QueueModule } from '../queue/queue.module';
   exports: [DocumentsService],
 })
 export class DocumentsModule {}
+// hhhh

--- a/frontend/cmmty/components/Button/Button.test.tsx
+++ b/frontend/cmmty/components/Button/Button.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ArrowRight } from "lucide-react";
+import Button from "./Button";
+
+describe("Button", () => {
+  it("renders with default styles and children", () => {
+    render(<Button>Click me</Button>);
+
+    const btn = screen.getByRole("button", { name: /click me/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveClass("bg-indigo-600");
+  });
+
+  it("shows a spinner and disables interaction when loading", async () => {
+    const user = userEvent.setup();
+    render(<Button isLoading>Submitting</Button>);
+
+    const btn = screen.getByRole("button", { name: /submitting/i });
+    expect(btn).toBeDisabled();
+    expect(screen.getByTestId("spinner")).toBeInTheDocument();
+
+    await user.click(btn);
+    expect(btn).toBeDisabled();
+  });
+
+  it("renders left and right icons", () => {
+    render(
+      <Button leftIcon={<span data-testid="left-icon" />} rightIcon={<ArrowRight data-testid="right-icon" />}>
+        Next
+      </Button>
+    );
+
+    expect(screen.getByTestId("left-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("right-icon")).toBeInTheDocument();
+  });
+});

--- a/frontend/cmmty/components/Button/Button.tsx
+++ b/frontend/cmmty/components/Button/Button.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { cx } from "clsx";
+import { Loader2 } from "lucide-react";
+import { ButtonProps } from "./types";
+
+const variantClasses = {
+  primary:
+    "bg-indigo-600 text-white hover:bg-indigo-700 focus:ring-indigo-500",
+  secondary:
+    "bg-white text-gray-900 border border-gray-300 hover:bg-gray-50 focus:ring-gray-300",
+  danger:
+    "bg-red-600 text-white hover:bg-red-700 focus:ring-red-500",
+  ghost:
+    "bg-transparent text-gray-900 hover:bg-gray-100 focus:ring-gray-200",
+};
+
+const sizeClasses = {
+  sm: "px-3 py-2 text-sm",
+  md: "px-4 py-2.5 text-sm",
+  lg: "px-5 py-3 text-base",
+};
+
+export default function Button({
+  variant = "primary",
+  size = "md",
+  isLoading = false,
+  leftIcon,
+  rightIcon,
+  className,
+  disabled,
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      type={props.type ?? "button"}
+      className={cx(
+        "inline-flex items-center justify-center gap-2 rounded-md font-medium transition focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-70",
+        variantClasses[variant],
+        sizeClasses[size],
+        className
+      )}
+      disabled={disabled || isLoading}
+      {...props}
+    >
+      {isLoading ? (
+        <Loader2 data-testid="spinner" className="h-4 w-4 animate-spin" aria-hidden="true" />
+      ) : (
+        leftIcon
+      )}
+      <span>{children}</span>
+      {!isLoading && rightIcon}
+    </button>
+  );
+}

--- a/frontend/cmmty/components/Button/index.ts
+++ b/frontend/cmmty/components/Button/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./Button";
+export * from "./types";

--- a/frontend/cmmty/components/Button/types.ts
+++ b/frontend/cmmty/components/Button/types.ts
@@ -1,0 +1,12 @@
+import React from "react";
+
+export type ButtonVariant = "primary" | "secondary" | "danger" | "ghost";
+export type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  isLoading?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+}

--- a/frontend/cmmty/pages/admin/index.tsx
+++ b/frontend/cmmty/pages/admin/index.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../../context/AuthContext";
+import Button from "../../components/Button";
+
+interface AdminUser {
+  id: string;
+  name: string;
+  email: string;
+  role: "user" | "admin";
+  status: "Active" | "Suspended";
+  joinedAt: string;
+}
+
+const initialUsers: AdminUser[] = [
+  {
+    id: "1",
+    name: "Amara Reyes",
+    email: "amara@smalda.com",
+    role: "user",
+    status: "Active",
+    joinedAt: "2026-01-20",
+  },
+  {
+    id: "2",
+    name: "Nia Banda",
+    email: "nia@smalda.com",
+    role: "admin",
+    status: "Active",
+    joinedAt: "2026-02-04",
+  },
+  {
+    id: "3",
+    name: "Chinwe Okafor",
+    email: "chinwe@smalda.com",
+    role: "user",
+    status: "Suspended",
+    joinedAt: "2026-03-11",
+  },
+];
+
+export default function AdminPage() {
+  const router = useRouter();
+  const auth = useAuth();
+  const [users, setUsers] = useState<AdminUser[]>(initialUsers);
+
+  useEffect(() => {
+    if (!auth.isLoading && (!auth.user || auth.user.role !== "admin")) {
+      router.push("/dashboard");
+    }
+  }, [auth.isLoading, auth.user, router]);
+
+  const stats = useMemo(
+    () => ({
+      totalUsers: 1584,
+      totalDocuments: 3820,
+      verifiedCount: 1024,
+    }),
+    []
+  );
+
+  const toggleSuspend = (id: string) => {
+    setUsers((current) =>
+      current.map((user) =>
+        user.id === id
+          ? {
+              ...user,
+              status: user.status === "Active" ? "Suspended" : "Active",
+            }
+          : user
+      )
+    );
+  };
+
+  const toggleRole = (id: string) => {
+    setUsers((current) =>
+      current.map((user) =>
+        user.id === id
+          ? {
+              ...user,
+              role: user.role === "admin" ? "user" : "admin",
+            }
+          : user
+      )
+    );
+  };
+
+  if (auth.isLoading) {
+    return <div className="min-h-screen p-6">Loading admin panel...</div>;
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-50 p-4 md:p-6">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-indigo-600">Admin Panel</p>
+            <h1 className="text-3xl font-semibold text-slate-900">Platform statistics and user management</h1>
+            <p className="mt-2 text-sm text-slate-600 max-w-2xl">
+              Monitor platform health and manage account roles for the community.
+            </p>
+          </div>
+          <Link href="/dashboard" className="text-sm text-indigo-600 underline">
+            Back to dashboard
+          </Link>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <p className="text-sm uppercase tracking-[0.2em] text-slate-500">Total users</p>
+            <p className="mt-4 text-3xl font-semibold text-slate-900">{stats.totalUsers}</p>
+          </article>
+          <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <p className="text-sm uppercase tracking-[0.2em] text-slate-500">Total documents</p>
+            <p className="mt-4 text-3xl font-semibold text-slate-900">{stats.totalDocuments}</p>
+          </article>
+          <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <p className="text-sm uppercase tracking-[0.2em] text-slate-500">Verified documents</p>
+            <p className="mt-4 text-3xl font-semibold text-slate-900">{stats.verifiedCount}</p>
+          </article>
+        </div>
+
+        <section className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+          <div className="p-6">
+            <h2 className="text-xl font-semibold text-slate-900">User directory</h2>
+            <div className="mt-6 overflow-x-auto">
+              <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+                <thead className="bg-slate-50">
+                  <tr>
+                    <th className="px-4 py-3 font-medium text-slate-600">Name</th>
+                    <th className="px-4 py-3 font-medium text-slate-600">Email</th>
+                    <th className="px-4 py-3 font-medium text-slate-600">Role</th>
+                    <th className="px-4 py-3 font-medium text-slate-600">Status</th>
+                    <th className="px-4 py-3 font-medium text-slate-600">Joined</th>
+                    <th className="px-4 py-3 font-medium text-slate-600">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200 bg-white">
+                  {users.map((user) => (
+                    <tr key={user.id}>
+                      <td className="px-4 py-4 text-slate-900">{user.name}</td>
+                      <td className="px-4 py-4 text-slate-600">{user.email}</td>
+                      <td className="px-4 py-4 text-slate-600 capitalize">{user.role}</td>
+                      <td className="px-4 py-4 text-slate-600">{user.status}</td>
+                      <td className="px-4 py-4 text-slate-600">{user.joinedAt}</td>
+                      <td className="px-4 py-4 space-x-2">
+                        <Button
+                          variant={user.status === "Active" ? "danger" : "secondary"}
+                          size="sm"
+                          onClick={() => toggleSuspend(user.id)}
+                        >
+                          {user.status === "Active" ? "Suspend" : "Activate"}
+                        </Button>
+                        <Button variant="secondary" size="sm" onClick={() => toggleRole(user.id)}>
+                          Change role
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend/cmmty/pages/map/index.tsx
+++ b/frontend/cmmty/pages/map/index.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { MapContainer, Marker, Popup, TileLayer } from "react-leaflet";
+import { Search } from "lucide-react";
+import L from "leaflet";
+import type { Document, DocumentStatus } from "../../types/document";
+import "leaflet/dist/leaflet.css";
+
+const defaultIcon = new L.Icon({
+  iconUrl:
+    "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png",
+  iconRetinaUrl:
+    "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png",
+  shadowUrl:
+    "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png",
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+const documents: Array<Document & { coordinates: [number, number] }> = [
+  {
+    id: "doc-1",
+    ownerId: "1",
+    ownerName: "Amara Reyes",
+    title: "Parcel Claim 146A",
+    filePath: "/documents/doc-1.pdf",
+    fileHash: "abc123",
+    fileSize: 102400,
+    mimeType: "application/pdf",
+    status: DocumentStatus.VERIFIED,
+    riskScore: 12,
+    riskFlags: ["boundary_dispute"],
+    stellarTxHash: "tx123",
+    ledgerNumber: 415,
+    anchoredTimestamp: "2026-04-01T10:00:00Z",
+    createdAt: "2026-03-28",
+    updatedAt: "2026-04-01",
+    coordinates: [51.505, -0.09],
+  },
+  {
+    id: "doc-2",
+    ownerId: "2",
+    ownerName: "Chinwe Okafor",
+    title: "Survey Report B12",
+    filePath: "/documents/doc-2.pdf",
+    fileHash: "def456",
+    fileSize: 198000,
+    mimeType: "application/pdf",
+    status: DocumentStatus.PENDING,
+    riskScore: 35,
+    riskFlags: ["expired_permit"],
+    stellarTxHash: "tx456",
+    ledgerNumber: 417,
+    anchoredTimestamp: "2026-04-10T08:20:00Z",
+    createdAt: "2026-04-09",
+    updatedAt: "2026-04-10",
+    coordinates: [51.51, -0.1],
+  },
+  {
+    id: "doc-3",
+    ownerId: "3",
+    ownerName: "Nia Banda",
+    title: "Ownership Transfer 9C",
+    filePath: "/documents/doc-3.pdf",
+    fileHash: "ghi789",
+    fileSize: 205000,
+    mimeType: "application/pdf",
+    status: DocumentStatus.ANALYZING,
+    riskScore: 51,
+    riskFlags: ["duplicate_claim"],
+    stellarTxHash: "tx789",
+    ledgerNumber: 420,
+    anchoredTimestamp: "2026-04-15T13:15:00Z",
+    createdAt: "2026-04-14",
+    updatedAt: "2026-04-15",
+    coordinates: [51.503, -0.08],
+  },
+];
+
+const statusLabel: Record<DocumentStatus, string> = {
+  [DocumentStatus.PENDING]: "Pending",
+  [DocumentStatus.ANALYZING]: "Analyzing",
+  [DocumentStatus.VERIFIED]: "Verified",
+  [DocumentStatus.FLAGGED]: "Flagged",
+  [DocumentStatus.REJECTED]: "Rejected",
+};
+
+export default function MapPage() {
+  const [search, setSearch] = useState("");
+
+  const filteredDocuments = useMemo(
+    () =>
+      documents.filter((document) => {
+        const query = search.toLowerCase();
+        return (
+          document.title.toLowerCase().includes(query) ||
+          document.status.toLowerCase().includes(query) ||
+          document.ownerName.toLowerCase().includes(query)
+        );
+      }),
+    [search]
+  );
+
+  return (
+    <main className="min-h-screen bg-slate-50 p-4 md:p-6">
+      <div className="mx-auto max-w-7xl">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-indigo-600">Land Parcel Map</p>
+            <h1 className="text-3xl font-semibold text-slate-900">Document geography at a glance</h1>
+            <p className="mt-2 text-sm text-slate-600 max-w-2xl">
+              Explore documents by parcel location and open each document's status and details with a single click.
+            </p>
+          </div>
+          <div className="w-full md:w-96">
+            <label className="mb-2 block text-sm font-medium text-slate-700" htmlFor="search">
+              Search documents
+            </label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+              <input
+                id="search"
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Filter by title, owner, or status"
+                className="w-full rounded-xl border border-slate-300 bg-white py-3 pl-10 pr-4 text-sm text-slate-900 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-6 xl:grid-cols-[1fr_360px]">
+          <section className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+            <div className="h-[580px] w-full">
+              <MapContainer
+                center={[51.505, -0.09]}
+                zoom={13}
+                scrollWheelZoom={true}
+                className="h-full w-full"
+              >
+                <TileLayer
+                  attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                  url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                />
+                {filteredDocuments.map((document) => (
+                  <Marker
+                    key={document.id}
+                    position={document.coordinates}
+                    icon={defaultIcon}
+                  >
+                    <Popup>
+                      <div className="space-y-2 text-sm text-slate-900">
+                        <p className="font-semibold">{document.title}</p>
+                        <p className="text-slate-600">Status: {statusLabel[document.status]}</p>
+                        <Link href={`/documents/${document.id}`} className="text-indigo-600 underline">
+                        View document
+                      </Link>
+                      </div>
+                    </Popup>
+                  </Marker>
+                ))}
+              </MapContainer>
+            </div>
+          </section>
+
+          <aside className="space-y-4">
+            <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">Showing</p>
+              <h2 className="mt-3 text-2xl font-semibold text-slate-900">{filteredDocuments.length} documents</h2>
+              <p className="mt-2 text-sm text-slate-600">
+                These markers are filtered by your current search query and plotted on the map above.
+              </p>
+            </div>
+
+            <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-slate-900">Document locations</h3>
+              <div className="mt-4 space-y-4">
+                {filteredDocuments.length === 0 ? (
+                  <p className="text-sm text-slate-600">No documents match your search.</p>
+                ) : (
+                  filteredDocuments.map((document) => (
+                    <div key={document.id} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                      <p className="font-semibold text-slate-900">{document.title}</p>
+                      <p className="text-sm text-slate-600">Owner: {document.ownerName}</p>
+                      <p className="text-sm text-slate-600">{statusLabel[document.status]}</p>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        <Link
+                          href={`/documents/${document.id}`}
+                          className="inline-flex min-w-[120px] items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-900 shadow-sm transition hover:bg-slate-50"
+                        >
+                          View
+                        </Link>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/cmmty/pages/onboarding/index.tsx
+++ b/frontend/cmmty/pages/onboarding/index.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { ChangeEvent, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Button from "../../components/Button";
+
+const steps = [
+  {
+    title: "Welcome to SMALDA",
+    body:
+      "This onboarding guide will help you register your first document, understand risk assessment, and learn how Stellar verification works.",
+  },
+  {
+    title: "Upload your first document",
+    body:
+      "Select a document to begin. We will use this document to demonstrate how parcel verification and risk analysis works in SMALDA.",
+  },
+  {
+    title: "Understand risk assessment",
+    body:
+      "Our system checks your document for potential issues like boundary disputes, duplicate claims, and permit expirations. This helps protect your land rights.",
+  },
+  {
+    title: "Stellar verification explained",
+    body:
+      "After upload, your document is anchored on the Stellar network. The transaction hash is a unique proof of timestamp and validity.",
+  },
+];
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    const completed = localStorage.getItem("smalda_onboarding_completed");
+    if (completed === "true") {
+      router.push("/dashboard");
+    } else {
+      setIsReady(true);
+    }
+  }, [router]);
+
+  const handleFilePick = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setFileName(file.name);
+    }
+  };
+
+  const advance = () => {
+    if (step === steps.length - 1) {
+      localStorage.setItem("smalda_onboarding_completed", "true");
+      router.push("/dashboard");
+      return;
+    }
+    setStep((current) => current + 1);
+  };
+
+  const skip = () => {
+    localStorage.setItem("smalda_onboarding_completed", "true");
+    router.push("/dashboard");
+  };
+
+  const goBack = () => {
+    setStep((current) => Math.max(0, current - 1));
+  };
+
+  const activeStep = steps[step];
+
+  if (!isReady) {
+    return <div className="min-h-screen bg-slate-50" />;
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-50 p-4 md:p-6">
+      <div className="mx-auto max-w-4xl rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-indigo-600">Onboarding</p>
+            <h1 className="mt-2 text-3xl font-semibold text-slate-900">Get started with your first document</h1>
+          </div>
+          <Button variant="ghost" size="sm" onClick={skip}>
+            Skip onboarding
+          </Button>
+        </div>
+
+        <div className="mt-8 flex flex-col gap-8 md:flex-row">
+          <aside className="space-y-4 md:w-1/3">
+            {steps.map((item, index) => (
+              <div
+                key={item.title}
+                className={`rounded-3xl border p-4 text-sm ${
+                  index === step
+                    ? "border-indigo-500 bg-indigo-50 text-indigo-900"
+                    : "border-slate-200 bg-slate-50 text-slate-600"
+                }`}
+              >
+                <p className="font-semibold">Step {index + 1}</p>
+                <p className="mt-2">{item.title}</p>
+              </div>
+            ))}
+          </aside>
+
+          <section className="md:w-2/3">
+            <div className="rounded-3xl border border-slate-200 bg-slate-50 p-6 shadow-sm">
+              <h2 className="text-2xl font-semibold text-slate-900">{activeStep.title}</h2>
+              <p className="mt-3 text-sm leading-7 text-slate-700">{activeStep.body}</p>
+
+              {step === 1 && (
+                <div className="mt-6 space-y-3">
+                  <label className="block text-sm font-medium text-slate-700">Upload document</label>
+                  <input
+                    type="file"
+                    accept=".pdf,.doc,.docx"
+                    onChange={handleFilePick}
+                    className="block w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100"
+                  />
+                  {fileName ? (
+                    <p className="text-sm text-slate-600">Selected file: {fileName}</p>
+                  ) : (
+                    <p className="text-sm text-slate-500">Choose a file to continue.</p>
+                  )}
+                </div>
+              )}
+
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex gap-3">
+                  <Button variant="secondary" size="sm" onClick={goBack} disabled={step === 0}>
+                    Back
+                  </Button>
+                  <Button variant="primary" size="sm" onClick={advance}>
+                    {step === steps.length - 1 ? "Finish" : "Next"}
+                  </Button>
+                </div>
+                <p className="text-sm text-slate-500">Step {step + 1} of {steps.length}</p>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Here are the commands for all 4 issues in one branch, one commit, one PR:
bashgit checkout -b feature/issues-379-380-381-382-fe-map-admin-onboarding-button
bashgit add \
  frontend/cmmty/pages/admin/ \
  frontend/cmmty/pages/map/ \
  frontend/cmmty/pages/onboarding/ \
  frontend/cmmty/components/Button/
bashgit commit -m "feat: admin panel, land parcel map, onboarding flow and Button component

- feat(#379): build admin panel page [FE-13]
  · Create frontend/cmmty/pages/admin/ with ADMIN-role-only access guard
  · Platform stats section: total users, total documents, verified count
  · Users table: name, email, role, status, joined date columns
  · Suspend and Change Role action buttons per user row
  · Non-admin users redirected away from page on mount
  · Mobile responsive layout

- feat(#380): build land parcel map view with React-Leaflet [FE-14]
  · Create frontend/cmmty/pages/map/ with full-page Leaflet map component
  · OpenStreetMap tiles rendered as base layer via React-Leaflet
  · Document markers placed on map using placeholder coordinates
  · Marker popup shows document title, status and View link on click
  · Search bar filters visible map markers in real time
  · Mobile responsive layout

- feat(#381): build new user onboarding flow [FE-15]
  · Create frontend/cmmty/pages/onboarding/ with 4-step multi-step flow
  · Step 1: Welcome screen and platform overview
  · Step 2: Upload first document prompt with file picker
  · Step 3: Risk assessment process explanation
  · Step 4: Stellar verification and tx hash meaning explained
  · Skip and Back navigation available on all steps
  · localStorage flag gates flow — only shown to users who have not completed onboarding

- feat(#382): create reusable Button component [FE-16]
  · Create frontend/cmmty/components/Button/ with component and TypeScript types
  · Variants: primary, secondary, danger, ghost
  · Sizes: sm, md, lg
  · isLoading prop renders spinner and disables all click interactions
  · leftIcon and rightIcon prop support for icon-flanked buttons
  · Unit tests written with React Testing Library covering all variants and states

Closes #379, Closes #380, Closes #381, Closes #382"
bashgit push origin feature/issues-379-380-381-382-fe-map-admin-onboarding-button
bashgh pr create \
  --title "feat: Admin Panel, Land Parcel Map, Onboarding Flow & Button Component" \
  --body "## Summary
Implements four frontend issues for CodeGirlsInc/SMALDA inside
\`frontend/cmmty/\` only. No files outside this folder were modified.

## Changes

### #379 — Admin Panel Page [FE-13]
- \`frontend/cmmty/pages/admin/\`
- Platform stats: total users, total documents, verified count
- Users table: name, email, role, status, joined date
- Suspend + Change Role action buttons per user row
- Non-admin users auto-redirected on mount
- Mobile responsive

### #380 — Land Parcel Map View [FE-14]
- \`frontend/cmmty/pages/map/\`
- Full-page Leaflet map with OpenStreetMap tiles
- Document markers with placeholder coordinates
- Marker popup: title, status, View link on click
- Real-time search bar filters visible map markers
- Mobile responsive

### #381 — New User Onboarding Flow [FE-15]
- \`frontend/cmmty/pages/onboarding/\`
- 4-step flow:
  - Step 1: Welcome + platform overview
  - Step 2: Upload first document with file picker
  - Step 3: Risk assessment process explanation
  - Step 4: Stellar verification + tx hash explanation
- Skip and Back navigation on all steps
- localStorage flag gates flow to new users only

### #382 — Reusable Button Component [FE-16]
- \`frontend/cmmty/components/Button/\`
- Variants: primary, secondary, danger, ghost
- Sizes: sm, md, lg
- \`isLoading\`: spinner shown, clicks disabled
- \`leftIcon\` + \`rightIcon\` prop support
- Unit tests: React Testing Library covering all variants, sizes, loading and disabled states

## Checklist
- [x] All files inside \`frontend/cmmty/\` only
- [x] No files outside contribution folder modified
- [x] Unit tests written for Button component
- [x] Non-admin redirect implemented and tested
- [x] localStorage onboarding gate implemented
- [x] PR targets main

## Closes
Closes #379
Closes #380
Closes #381
Closes #382