### PR TITLE
Created the custom and registration

### DIFF
--- a/backend/src/dispute/dispute-reason-classifier.service.ts
+++ b/backend/src/dispute/dispute-reason-classifier.service.ts
@@ -1,0 +1,220 @@
+// src/dispute-reason-classifier/dispute-reason-classifier.service.ts
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DisputeReason } from './entities/dispute-reason.entity';
+
+@Injectable()
+export class DisputeReasonClassifierService {
+  constructor(
+    @InjectRepository(DisputeReason)
+    private readonly reasonRepo: Repository<DisputeReason>,
+  ) {}
+
+  async findAllReasons(): Promise<DisputeReason[]> {
+    return this.reasonRepo.find();
+  }
+
+  async classifyDispute(description: string): Promise<DisputeReason | null> {
+    const reasons = await this.findAllReasons();
+
+    const matchedReason = reasons.find((reason) =>
+      description.toLowerCase().includes(reason.name.toLowerCase()),
+    );
+
+    return matchedReason || null;
+  }
+
+  async log(context: AuditContext, data: AuditLogData): Promise<AuditLog> {
+      const createDto: CreateAuditLogDto = {
+        userId: context.userId,
+        userEmail: context.userEmail,
+        action: data.action,
+        severity: data.severity,
+        description: data.description,
+        resourceType: data.resourceType,
+        resourceId: data.resourceId,
+        metadata: data.metadata,
+        ipAddress: context.ipAddress,
+        userAgent: context.userAgent,
+        success: data.success,
+        errorMessage: data.errorMessage,
+      }
+  
+      return await this.createLog(createDto)
+    }
+  
+    async findAll(query: AuditLogQueryDto): Promise<{
+      logs: AuditLog[]
+      total: number
+      limit: number
+      offset: number
+    }> {
+      const {
+        userId,
+        action,
+        severity,
+        resourceType,
+        resourceId,
+        startDate,
+        endDate,
+        limit = 50,
+        offset = 0,
+        search,
+      } = query
+  
+      const whereConditions: any = {}
+  
+      if (userId) {
+        whereConditions.userId = userId
+      }
+  
+      if (action) {
+        whereConditions.action = action
+      }
+  
+      if (severity) {
+        whereConditions.severity = severity
+      }
+  
+      if (resourceType) {
+        whereConditions.resourceType = resourceType
+      }
+  
+      if (resourceId) {
+        whereConditions.resourceId = resourceId
+      }
+  
+      if (startDate && endDate) {
+        whereConditions.createdAt = Between(new Date(startDate), new Date(endDate))
+      } else if (startDate) {
+        whereConditions.createdAt = Between(new Date(startDate), new Date())
+      }
+  
+      if (search) {
+        whereConditions.description = Like(`%${search}%`)
+      }
+  
+      const [logs, total] = await this.auditLogRepository.findAndCount({
+        where: whereConditions,
+        order: { createdAt: "DESC" },
+        take: limit,
+        skip: offset,
+      })
+  
+      return {
+        logs,
+        total,
+        limit,
+        offset,
+      }
+    }
+  
+    async findOne(id: string): Promise<AuditLog | null> {
+      return await this.auditLogRepository.findOne({
+        where: { id },
+      })
+    }
+  
+    async findByUser(userId: string, limit = 50, offset = 0): Promise<AuditLog[]> {
+      return await this.auditLogRepository.find({
+        where: { userId },
+        order: { createdAt: "DESC" },
+        take: limit,
+        skip: offset,
+      })
+    }
+  
+    async findByResource(resourceType: string, resourceId: string): Promise<AuditLog[]> {
+      return await this.auditLogRepository.find({
+        where: { resourceType, resourceId },
+        order: { createdAt: "DESC" },
+      })
+    }
+  
+    async findByAction(action: string, limit = 50, offset = 0): Promise<AuditLog[]> {
+      return await this.auditLogRepository.find({
+        where: { action: action as any },
+        order: { createdAt: "DESC" },
+        take: limit,
+        skip: offset,
+      })
+    }
+  
+    async getAuditStatistics(
+      startDate?: Date,
+      endDate?: Date,
+    ): Promise<{
+      totalLogs: number
+      actionCounts: Record<string, number>
+      severityCounts: Record<string, number>
+      userCounts: Record<string, number>
+      dailyCounts: Record<string, number>
+    }> {
+      const whereCondition: any = {}
+  
+      if (startDate && endDate) {
+        whereCondition.createdAt = Between(startDate, endDate)
+      }
+  
+      const logs = await this.auditLogRepository.find({
+        where: whereCondition,
+        order: { createdAt: "DESC" },
+      })
+  
+      const actionCounts: Record<string, number> = {}
+      const severityCounts: Record<string, number> = {}
+      const userCounts: Record<string, number> = {}
+      const dailyCounts: Record<string, number> = {}
+  
+      logs.forEach((log) => {
+        // Count by action
+        actionCounts[log.action] = (actionCounts[log.action] || 0) + 1
+  
+        // Count by severity
+        severityCounts[log.severity] = (severityCounts[log.severity] || 0) + 1
+  
+        // Count by user
+        userCounts[log.userId] = (userCounts[log.userId] || 0) + 1
+  
+        // Count by day
+        const day = log.createdAt.toISOString().split("T")[0]
+        dailyCounts[day] = (dailyCounts[day] || 0) + 1
+      })
+  
+      return {
+        totalLogs: logs.length,
+        actionCounts,
+        severityCounts,
+        userCounts,
+        dailyCounts,
+      }
+    }
+  
+    async findSuspiciousActivity(userId?: string): Promise<AuditLog[]> {
+      const whereConditions: any = {
+        severity: In(["HIGH", "CRITICAL"]),
+      }
+  
+      if (userId) {
+        whereConditions.userId = userId
+      }
+  
+      return await this.auditLogRepository.find({
+        where: whereConditions,
+        order: { createdAt: "DESC" },
+        take: 100,
+      })
+    }
+  
+    async deleteOldLogs(daysToKeep = 365): Promise<number> {
+      const cutoffDate = new Date()
+      cutoffDate.setDate(cutoffDate.getDate() - daysToKeep)
+  
+      const result = await this.auditLogRepository.delete({
+        createdAt: Between(new Date("1970-01-01"), cutoffDate),
+      })
+  
+      return result.affected || 0
+    }
+}


### PR DESCRIPTION
[BE-39] Add custom risk assessment rules configuration

Allow admins to configure custom risk rules through an API rather than hardcoding flag logic inside backend/cmmty/.

Acceptance Criteria
 Create backend/cmmty/risk-rules/ with entity, module, controller, and service
 RiskRule entity: id, name, description, weight, condition (JSON), isActive
 Implement CRUD endpoints at /cmmty/admin/risk-rules
 Risk assessment service loads active custom rules from DB and evaluates them
 Write unit tests for rule evaluation logic
closes #365 

 [FE-02] Build the registration/signup page

Overview
Build the user registration page inside frontend/cmmty/.

Acceptance Criteria
 Create frontend/cmmty/pages/register/ with the page component
 Render: full name, email, password, confirm password fields
 Show inline validation errors (password mismatch, invalid email, etc.)
 Show loading and success states
 Redirect to email-verification-pending page after successful registration
 Mobile responsive layout
 closes #368